### PR TITLE
fix: add VITE_CONFIG_BASE env var to set BASE in vite.config.ts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        run: pnpm build:pages
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
+    "build:pages": "tsc && VITE_CONFIG_BASE='/SIMDE/' vite build",
     "check": "biome check --apply ./src",
     "dev": "vite",
     "docs": "typedoc src/index.ts --excludePrivate --mode file --theme minimal --out build/docs",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/SIMDE/"
+  base: process.env.VITE_CONFIG_BASE ?? "/",
 })


### PR DESCRIPTION
This simple change allows to easily deploy to GitHub Pages with the required `/SIMDE/` base URL path while still using the default `/` route for the rest of deployments, including development environments.

In the future, when build configurations increase in complexity, this approach could be replaced in favor of more specific configs that extend the base `vite.config.ts` file, e.g. `github-pages.config.ts` inside a `deploy/vite` dir.