### PR TITLE
feat(parser): make line count header optional

### DIFF
--- a/src/core/Common/CodeParser.ts
+++ b/src/core/Common/CodeParser.ts
@@ -7,36 +7,36 @@ import {
   seq,
   tok,
   opt_sc,
-  Token,
+  type Token,
   TokenError,
   alt_sc,
   fail,
-  TokenPosition,
+  type TokenPosition,
 } from "typescript-parsec";
 import { OpcodesNames, opcodeToFormat } from "./Opcodes";
 import { Formats, FormatsNames } from "./InstructionFormats";
 import { Instruction } from "./Instruction";
 
 enum Tokens {
-  Inmediate,
-  RegFP,
-  RegGP,
-  Id,
-  Label,
-  BraketOpen,
-  BraketClose,
-  Number,
-  Comma,
-  Space,
-  NewLine,
-  Comment,
+  Inmediate = 0,
+  RegFP = 1,
+  RegGP = 2,
+  Id = 3,
+  Label = 4,
+  BraketOpen = 5,
+  BraketClose = 6,
+  Number = 7,
+  Comma = 8,
+  Space = 9,
+  NewLine = 10,
+  Comment = 11,
 }
 
 enum RegType {
-  FP,
-  GP,
+  FP = 0,
+  GP = 1,
 }
-let RegTypeNames: string[] = ["FP", "GP"];
+const RegTypeNames: string[] = ["FP", "GP"];
 
 interface Reg {
   type: RegType;
@@ -81,7 +81,7 @@ const regParser = apply(
   alt_sc(tok(Tokens.RegFP), tok(Tokens.RegGP)),
   (reg: Token<Tokens.RegFP> | Token<Tokens.RegGP>) => {
     let type = RegType.GP;
-    if (reg.kind == Tokens.RegFP) {
+    if (reg.kind === Tokens.RegFP) {
       type = RegType.FP;
     }
     return {
@@ -108,7 +108,7 @@ const addressParser = apply(
       Token<Tokens.BraketClose>
     ]
   ) => {
-    if (address[2].type == RegType.FP) {
+    if (address[2].type === RegType.FP) {
       throw new TokenError(
         address[2].pos,
         "Address register cannot be FP register"
@@ -121,12 +121,11 @@ const addressParser = apply(
 const opcodeParser = apply(
   tok(Tokens.Id),
   (opcodeTok: Token<Tokens.Id>): OpcodeToken => {
-    let opcode: number = OpcodesNames.indexOf(opcodeTok.text);
+    const opcode: number = OpcodesNames.indexOf(opcodeTok.text);
     if (opcode !== -1) {
       return { opcode: opcode, pos: opcodeTok.pos };
-    } else {
-      throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
     }
+    throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
   }
 );
 
@@ -156,16 +155,16 @@ export class CodeParser {
   }
 
   private parse(code: string) {
-    let result = expectSingleResult(
+    const result = expectSingleResult(
       expectEOF(this.genCodeParser().parse(tokenizer.parse(code)))
     );
 
     // Create labels and instructions
     let pos = 0;
     for (let i = 0; i < result[1].length; i++) {
-      let line = result[1][i];
-      if ("kind" in line && line.kind == Tokens.Label) {
-        let name = line.text.slice(0, -1);
+      const line = result[1][i];
+      if ("kind" in line && line.kind === Tokens.Label) {
+        const name = line.text.slice(0, -1);
         if (name in this._labels) {
           throw new Error(
             `Error at instruction ${pos}, label ${line.text.slice(
@@ -208,12 +207,12 @@ export class CodeParser {
           | [OpcodeToken, Reg, Address]
           | [OpcodeToken, Reg, Reg, Token<Tokens.Id>]
       ) => {
-        var type: Formats;
-        var instruction: Instruction = new Instruction();
-        var pos: TokenPosition;
+        let type: Formats;
+        const instruction: Instruction = new Instruction();
+        let pos: TokenPosition;
 
         // set the opcode and get the current position
-        if (operation instanceof Array) {
+        if (Array.isArray(operation)) {
           instruction.opcode = operation[0].opcode;
           pos = operation[0].pos;
         } else {
@@ -222,9 +221,9 @@ export class CodeParser {
         }
 
         // Check the recived instruction format and set the operands
-        if (!(operation instanceof Array)) {
+        if (!Array.isArray(operation)) {
           type = Formats.Noop;
-        } else if ("num" in operation[2] && operation.length == 4) {
+        } else if ("num" in operation[2] && operation.length === 4) {
           if (operation[2].type !== operation[1].type) {
             throw new TokenError(
               operation[2].pos,
@@ -234,19 +233,20 @@ export class CodeParser {
             );
           }
 
-          if (typeof operation[3] == "number") {
+          if (typeof operation[3] === "number") {
             type = Formats.GeneralRegisterAndInmediate;
 
             // Check that the registers are in bounds
             if (operation[1].num > this._generalRegisters) {
               throw new TokenError(
                 operation[1].pos,
-                `Destiny register number out of bounds`
+                "Destiny register number out of bounds"
               );
-            } else if (operation[2].num > this._generalRegisters) {
+            }
+            if (operation[2].num > this._generalRegisters) {
               throw new TokenError(
                 operation[2].pos,
-                `Operand 1 register number out of bounds`
+                "Operand 1 register number out of bounds"
               );
             }
 
@@ -255,12 +255,12 @@ export class CodeParser {
             instruction.setOperand(
               2,
               operation[3],
-              "#" + operation[3].toString()
+              `#${operation[3].toString()}`
             );
-            if (operation[1].type == RegType.FP) {
+            if (operation[1].type === RegType.FP) {
               throw new TokenError(
                 operation[1].pos,
-                `Inmediate operand not allowed for floating point registers`
+                "Inmediate operand not allowed for floating point registers"
               );
             }
           } else if ("num" in operation[3]) {
@@ -273,7 +273,7 @@ export class CodeParser {
               );
             }
 
-            if (operation[1].type == RegType.FP) {
+            if (operation[1].type === RegType.FP) {
               type = Formats.TwoFloatingRegisters;
             } else {
               type = Formats.TwoGeneralRegisters;
@@ -283,17 +283,19 @@ export class CodeParser {
             if (operation[1].num > this._generalRegisters) {
               throw new TokenError(
                 operation[1].pos,
-                `Destiny register number out of bounds`
+                "Destiny register number out of bounds"
               );
-            } else if (operation[2].num > this._generalRegisters) {
+            }
+            if (operation[2].num > this._generalRegisters) {
               throw new TokenError(
                 operation[2].pos,
-                `Operand 1 register number out of bounds`
+                "Operand 1 register number out of bounds"
               );
-            } else if (operation[3].num > this._generalRegisters) {
+            }
+            if (operation[3].num > this._generalRegisters) {
               throw new TokenError(
                 operation[3].pos,
-                `Operand 2 register number out of bounds`
+                "Operand 2 register number out of bounds"
               );
             }
 
@@ -307,12 +309,13 @@ export class CodeParser {
             if (operation[1].num > this._generalRegisters) {
               throw new TokenError(
                 operation[1].pos,
-                `Operand 1 register number out of bounds`
+                "Operand 1 register number out of bounds"
               );
-            } else if (operation[2].num > this._generalRegisters) {
+            }
+            if (operation[2].num > this._generalRegisters) {
               throw new TokenError(
                 operation[2].pos,
-                `Operand 2 register number out of bounds`
+                "Operand 2 register number out of bounds"
               );
             }
 
@@ -320,8 +323,8 @@ export class CodeParser {
             instruction.setOperand(1, operation[2].num, operation[2].text);
             instruction.setOperand(2, undefined, operation[3].text);
           }
-        } else if (operation.length == 3) {
-          if (operation[1].type == RegType.FP) {
+        } else if (operation.length === 3) {
+          if (operation[1].type === RegType.FP) {
             type = Formats.FloatingLoadStore;
           } else {
             type = Formats.GeneralLoadStore;
@@ -331,17 +334,19 @@ export class CodeParser {
           if (operation[1].num > this._generalRegisters) {
             throw new TokenError(
               operation[1].pos,
-              `Destiny register number out of bounds`
+              "Destiny register number out of bounds"
             );
-          } else if (operation[2].reg.num > this._generalRegisters) {
+          }
+          if (operation[2].reg.num > this._generalRegisters) {
             throw new TokenError(
               operation[2].reg.pos,
-              `Adress register number out of bounds`
+              "Adress register number out of bounds"
             );
-          } else if (operation[2].address > this._memorySize) {
+          }
+          if (operation[2].address > this._memorySize) {
             throw new TokenError(
               operation[2].reg.pos,
-              `Memory address out of bounds`
+              "Memory address out of bounds"
             );
           }
 
@@ -354,11 +359,11 @@ export class CodeParser {
           instruction.setOperand(
             2,
             operation[2].reg.num,
-            "(" + operation[2].reg.text + ")"
+            `(${operation[2].reg.text})`
           );
         }
 
-        let expectedType = opcodeToFormat(instruction.opcode);
+        const expectedType = opcodeToFormat(instruction.opcode);
         if (type !== expectedType) {
           //return fail(`Invalid instruction format for ${OpcodesNames[instruction.opcode]}. Expected ${FormatsNames[expectedType]} format, got ${FormatsNames[type]} format or similar`);
           throw new TokenError(

--- a/src/core/Common/CodeParser.ts
+++ b/src/core/Common/CodeParser.ts
@@ -1,383 +1,383 @@
 import {
-	apply,
-	buildLexer,
-	expectEOF,
-	expectSingleResult,
-	rep_sc,
-	seq,
-	tok,
-	opt_sc,
-	type Token,
-	TokenError,
-	alt_sc,
-	fail,
-	type TokenPosition,
+  apply,
+  buildLexer,
+  expectEOF,
+  expectSingleResult,
+  rep_sc,
+  seq,
+  tok,
+  opt_sc,
+  type Token,
+  TokenError,
+  alt_sc,
+  fail,
+  type TokenPosition,
 } from "typescript-parsec";
 import { OpcodesNames, opcodeToFormat } from "./Opcodes";
 import { Formats, FormatsNames } from "./InstructionFormats";
 import { Instruction } from "./Instruction";
 
 enum Tokens {
-	Inmediate = 0,
-	RegFP = 1,
-	RegGP = 2,
-	Id = 3,
-	Label = 4,
-	BraketOpen = 5,
-	BraketClose = 6,
-	Number = 7,
-	Comma = 8,
-	Space = 9,
-	NewLine = 10,
-	Comment = 11,
+  Inmediate = 0,
+  RegFP = 1,
+  RegGP = 2,
+  Id = 3,
+  Label = 4,
+  BraketOpen = 5,
+  BraketClose = 6,
+  Number = 7,
+  Comma = 8,
+  Space = 9,
+  NewLine = 10,
+  Comment = 11,
 }
 
 enum RegType {
-	FP = 0,
-	GP = 1,
+  FP = 0,
+  GP = 1,
 }
 const RegTypeNames: string[] = ["FP", "GP"];
 
 interface Reg {
-	type: RegType;
-	pos: TokenPosition;
-	num: number;
-	text: string;
+  type: RegType;
+  pos: TokenPosition;
+  num: number;
+  text: string;
 }
 
 interface Address {
-	address: number;
-	reg: Reg;
+  address: number;
+  reg: Reg;
 }
 
 interface OpcodeToken {
-	opcode: number;
-	pos: TokenPosition;
+  opcode: number;
+  pos: TokenPosition;
 }
 
 const tokenizer = buildLexer([
-	[true, /^#[+-]?[0-9]+/g, Tokens.Inmediate],
-	[true, /^[Ff][0-9]+/g, Tokens.RegFP],
-	[true, /^[Rr][0-9]+/g, Tokens.RegGP],
-	[true, /^[A-Za-z][A-Za-z0-9]*\:/g, Tokens.Label],
-	[true, /^[A-Za-z][A-Za-z0-9]*/g, Tokens.Id],
-	[true, /^\(/g, Tokens.BraketOpen],
-	[true, /^\)/g, Tokens.BraketClose],
-	[true, /^[+-]?[0-9]+/g, Tokens.Number],
-	[false, /^\,/g, Tokens.Comma],
-	[false, /^[ \t\v\f]+/g, Tokens.Space],
-	[false, /^\n/g, Tokens.NewLine],
-	[false, /^\/\/.*\n/g, Tokens.Comment],
+  [true, /^#[+-]?[0-9]+/g, Tokens.Inmediate],
+  [true, /^[Ff][0-9]+/g, Tokens.RegFP],
+  [true, /^[Rr][0-9]+/g, Tokens.RegGP],
+  [true, /^[A-Za-z][A-Za-z0-9]*\:/g, Tokens.Label],
+  [true, /^[A-Za-z][A-Za-z0-9]*/g, Tokens.Id],
+  [true, /^\(/g, Tokens.BraketOpen],
+  [true, /^\)/g, Tokens.BraketClose],
+  [true, /^[+-]?[0-9]+/g, Tokens.Number],
+  [false, /^\,/g, Tokens.Comma],
+  [false, /^[ \t\v\f]+/g, Tokens.Space],
+  [false, /^\n/g, Tokens.NewLine],
+  [false, /^\/\/.*\n/g, Tokens.Comment],
 ]);
 
 const inmParser = apply(
-	tok(Tokens.Inmediate),
-	(num: Token<Tokens.Inmediate>) => {
-		return +num.text.slice(1);
-	},
+  tok(Tokens.Inmediate),
+  (num: Token<Tokens.Inmediate>) => {
+    return +num.text.slice(1);
+  }
 );
 
 const regParser = apply(
-	alt_sc(tok(Tokens.RegFP), tok(Tokens.RegGP)),
-	(reg: Token<Tokens.RegFP> | Token<Tokens.RegGP>) => {
-		let type = RegType.GP;
-		if (reg.kind === Tokens.RegFP) {
-			type = RegType.FP;
-		}
-		return {
-			type: type,
-			pos: reg.pos,
-			num: +reg.text.slice(1),
-			text: reg.text,
-		};
-	},
+  alt_sc(tok(Tokens.RegFP), tok(Tokens.RegGP)),
+  (reg: Token<Tokens.RegFP> | Token<Tokens.RegGP>) => {
+    let type = RegType.GP;
+    if (reg.kind === Tokens.RegFP) {
+      type = RegType.FP;
+    }
+    return {
+      type: type,
+      pos: reg.pos,
+      num: +reg.text.slice(1),
+      text: reg.text,
+    };
+  }
 );
 
 const addressParser = apply(
-	seq(
-		opt_sc(tok(Tokens.Number)),
-		tok(Tokens.BraketOpen),
-		regParser,
-		tok(Tokens.BraketClose),
-	),
-	(
-		address: [
-			Token<Tokens.Number>,
-			Token<Tokens.BraketOpen>,
-			Reg,
-			Token<Tokens.BraketClose>,
-		],
-	) => {
-		if (address[2].type === RegType.FP) {
-			throw new TokenError(
-				address[2].pos,
-				"Address register cannot be FP register",
-			);
-		}
-		return { address: address[0] ? +address[0].text : 0, reg: address[2] };
-	},
+  seq(
+    opt_sc(tok(Tokens.Number)),
+    tok(Tokens.BraketOpen),
+    regParser,
+    tok(Tokens.BraketClose)
+  ),
+  (
+    address: [
+      Token<Tokens.Number>,
+      Token<Tokens.BraketOpen>,
+      Reg,
+      Token<Tokens.BraketClose>
+    ]
+  ) => {
+    if (address[2].type === RegType.FP) {
+      throw new TokenError(
+        address[2].pos,
+        "Address register cannot be FP register"
+      );
+    }
+    return { address: address[0] ? +address[0].text : 0, reg: address[2] };
+  }
 );
 
 const opcodeParser = apply(
-	tok(Tokens.Id),
-	(opcodeTok: Token<Tokens.Id>): OpcodeToken => {
-		const opcode: number = OpcodesNames.indexOf(opcodeTok.text);
-		if (opcode !== -1) {
-			return { opcode: opcode, pos: opcodeTok.pos };
-		}
-		throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
-	},
+  tok(Tokens.Id),
+  (opcodeTok: Token<Tokens.Id>): OpcodeToken => {
+    const opcode: number = OpcodesNames.indexOf(opcodeTok.text);
+    if (opcode !== -1) {
+      return { opcode: opcode, pos: opcodeTok.pos };
+    }
+    throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
+  }
 );
 
 export class CodeParser {
-	private _instructions: Instruction[] = [];
-	private _labels: { [k: string]: number } = {};
+  private _instructions: Instruction[] = [];
+  private _labels: { [k: string]: number } = {};
 
-	private _generalRegisters: number;
-	private _memorySize: number;
+  private _generalRegisters: number;
+  private _memorySize: number;
 
-	public get instructions(): Instruction[] {
-		return this._instructions;
-	}
+  public get instructions(): Instruction[] {
+    return this._instructions;
+  }
 
-	public get labels(): { [k: string]: number } {
-		return this._labels;
-	}
+  public get labels(): { [k: string]: number } {
+    return this._labels;
+  }
 
-	public get lines(): number {
-		return this._instructions.length;
-	}
+  public get lines(): number {
+    return this._instructions.length;
+  }
 
-	constructor(code: string, generalRegisters: number, memorySize: number) {
-		this._generalRegisters = generalRegisters;
-		this._memorySize = memorySize;
-		this.parse(code);
-	}
+  constructor(code: string, generalRegisters: number, memorySize: number) {
+    this._generalRegisters = generalRegisters;
+    this._memorySize = memorySize;
+    this.parse(code);
+  }
 
-	private parse(code: string) {
-		const result = expectSingleResult(
-			expectEOF(this.genCodeParser().parse(tokenizer.parse(code))),
-		);
+  private parse(code: string) {
+    const result = expectSingleResult(
+      expectEOF(this.genCodeParser().parse(tokenizer.parse(code)))
+    );
 
-		// Create labels and instructions
-		let pos = 0;
-		for (let i = 0; i < result[1].length; i++) {
-			const line = result[1][i];
-			if ("kind" in line && line.kind === Tokens.Label) {
-				const name = line.text.slice(0, -1);
-				if (name in this._labels) {
-					throw new Error(
-						`Error at instruction ${pos}, label ${line.text.slice(
-							0,
-							-1,
-						)} already exists`,
-					);
-				}
-				this._labels[name] = pos;
-			} else if (line instanceof Instruction) {
-				this._instructions.push(line);
-				pos++;
-			} else {
-				throw new Error(`Unexpected code parser fail: ${JSON.stringify(line)}`);
-			}
-		}
-	}
+    // Create labels and instructions
+    let pos = 0;
+    for (let i = 0; i < result[1].length; i++) {
+      const line = result[1][i];
+      if ("kind" in line && line.kind === Tokens.Label) {
+        const name = line.text.slice(0, -1);
+        if (name in this._labels) {
+          throw new Error(
+            `Error at instruction ${pos}, label ${line.text.slice(
+              0,
+              -1
+            )} already exists`
+          );
+        }
+        this._labels[name] = pos;
+      } else if (line instanceof Instruction) {
+        this._instructions.push(line);
+        pos++;
+      } else {
+        throw new Error(`Unexpected code parser fail: ${JSON.stringify(line)}`);
+      }
+    }
+  }
 
-	private genCodeParser() {
-		return seq(
-			opt_sc(tok(Tokens.Number)),
-			rep_sc(alt_sc(this.genOperationParser(), tok(Tokens.Label))),
-		);
-	}
+  private genCodeParser() {
+    return seq(
+      opt_sc(tok(Tokens.Number)),
+      rep_sc(alt_sc(this.genOperationParser(), tok(Tokens.Label)))
+    );
+  }
 
-	private genOperationParser() {
-		return apply(
-			alt_sc(
-				seq(opcodeParser, regParser, regParser, regParser),
-				seq(opcodeParser, regParser, regParser, inmParser),
-				seq(opcodeParser, regParser, regParser, tok(Tokens.Id)),
-				seq(opcodeParser, regParser, addressParser),
-				opcodeParser,
-			), // The order is important, the first succesfull match is the one that is returned
-			(
-				operation:
-					| OpcodeToken
-					| [OpcodeToken, Reg, Reg, Reg]
-					| [OpcodeToken, Reg, Reg, number]
-					| [OpcodeToken, Reg, Address]
-					| [OpcodeToken, Reg, Reg, Token<Tokens.Id>],
-			) => {
-				let type: Formats;
-				const instruction: Instruction = new Instruction();
-				let pos: TokenPosition;
+  private genOperationParser() {
+    return apply(
+      alt_sc(
+        seq(opcodeParser, regParser, regParser, regParser),
+        seq(opcodeParser, regParser, regParser, inmParser),
+        seq(opcodeParser, regParser, regParser, tok(Tokens.Id)),
+        seq(opcodeParser, regParser, addressParser),
+        opcodeParser
+      ), // The order is important, the first succesfull match is the one that is returned
+      (
+        operation:
+          | OpcodeToken
+          | [OpcodeToken, Reg, Reg, Reg]
+          | [OpcodeToken, Reg, Reg, number]
+          | [OpcodeToken, Reg, Address]
+          | [OpcodeToken, Reg, Reg, Token<Tokens.Id>]
+      ) => {
+        let type: Formats;
+        const instruction: Instruction = new Instruction();
+        let pos: TokenPosition;
 
-				// set the opcode and get the current position
-				if (Array.isArray(operation)) {
-					instruction.opcode = operation[0].opcode;
-					pos = operation[0].pos;
-				} else {
-					instruction.opcode = operation.opcode;
-					pos = operation.pos;
-				}
+        // set the opcode and get the current position
+        if (Array.isArray(operation)) {
+          instruction.opcode = operation[0].opcode;
+          pos = operation[0].pos;
+        } else {
+          instruction.opcode = operation.opcode;
+          pos = operation.pos;
+        }
 
-				// Check the recived instruction format and set the operands
-				if (!Array.isArray(operation)) {
-					type = Formats.Noop;
-				} else if ("num" in operation[2] && operation.length === 4) {
-					if (operation[2].type !== operation[1].type) {
-						throw new TokenError(
-							operation[2].pos,
-							`Second operand register type(${
-								RegTypeNames[operation[2].type]
-							}) mistmatch. Expected ${RegTypeNames[operation[1].type]}`,
-						);
-					}
+        // Check the recived instruction format and set the operands
+        if (!Array.isArray(operation)) {
+          type = Formats.Noop;
+        } else if ("num" in operation[2] && operation.length === 4) {
+          if (operation[2].type !== operation[1].type) {
+            throw new TokenError(
+              operation[2].pos,
+              `Second operand register type(${
+                RegTypeNames[operation[2].type]
+              }) mistmatch. Expected ${RegTypeNames[operation[1].type]}`
+            );
+          }
 
-					if (typeof operation[3] === "number") {
-						type = Formats.GeneralRegisterAndInmediate;
+          if (typeof operation[3] === "number") {
+            type = Formats.GeneralRegisterAndInmediate;
 
-						// Check that the registers are in bounds
-						if (operation[1].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[1].pos,
-								"Destiny register number out of bounds",
-							);
-						}
-						if (operation[2].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[2].pos,
-								"Operand 1 register number out of bounds",
-							);
-						}
+            // Check that the registers are in bounds
+            if (operation[1].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[1].pos,
+                "Destiny register number out of bounds"
+              );
+            }
+            if (operation[2].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[2].pos,
+                "Operand 1 register number out of bounds"
+              );
+            }
 
-						instruction.setOperand(0, operation[1].num, operation[1].text);
-						instruction.setOperand(1, operation[2].num, operation[2].text);
-						instruction.setOperand(
-							2,
-							operation[3],
-							`#${operation[3].toString()}`,
-						);
-						if (operation[1].type === RegType.FP) {
-							throw new TokenError(
-								operation[1].pos,
-								"Inmediate operand not allowed for floating point registers",
-							);
-						}
-					} else if ("num" in operation[3]) {
-						if (operation[3].type !== operation[1].type) {
-							throw new TokenError(
-								operation[3].pos,
-								`Third operand register type(${
-									RegTypeNames[operation[3].type]
-								}) mistmatch. Expected ${RegTypeNames[operation[1].type]}`,
-							);
-						}
+            instruction.setOperand(0, operation[1].num, operation[1].text);
+            instruction.setOperand(1, operation[2].num, operation[2].text);
+            instruction.setOperand(
+              2,
+              operation[3],
+              `#${operation[3].toString()}`
+            );
+            if (operation[1].type === RegType.FP) {
+              throw new TokenError(
+                operation[1].pos,
+                "Inmediate operand not allowed for floating point registers"
+              );
+            }
+          } else if ("num" in operation[3]) {
+            if (operation[3].type !== operation[1].type) {
+              throw new TokenError(
+                operation[3].pos,
+                `Third operand register type(${
+                  RegTypeNames[operation[3].type]
+                }) mistmatch. Expected ${RegTypeNames[operation[1].type]}`
+              );
+            }
 
-						if (operation[1].type === RegType.FP) {
-							type = Formats.TwoFloatingRegisters;
-						} else {
-							type = Formats.TwoGeneralRegisters;
-						}
+            if (operation[1].type === RegType.FP) {
+              type = Formats.TwoFloatingRegisters;
+            } else {
+              type = Formats.TwoGeneralRegisters;
+            }
 
-						// Check that the registers are in bounds
-						if (operation[1].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[1].pos,
-								"Destiny register number out of bounds",
-							);
-						}
-						if (operation[2].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[2].pos,
-								"Operand 1 register number out of bounds",
-							);
-						}
-						if (operation[3].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[3].pos,
-								"Operand 2 register number out of bounds",
-							);
-						}
+            // Check that the registers are in bounds
+            if (operation[1].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[1].pos,
+                "Destiny register number out of bounds"
+              );
+            }
+            if (operation[2].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[2].pos,
+                "Operand 1 register number out of bounds"
+              );
+            }
+            if (operation[3].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[3].pos,
+                "Operand 2 register number out of bounds"
+              );
+            }
 
-						instruction.setOperand(0, operation[1].num, operation[1].text);
-						instruction.setOperand(1, operation[2].num, operation[2].text);
-						instruction.setOperand(2, operation[3].num, operation[3].text);
-					} else if ("pos" in operation[3]) {
-						type = Formats.Jump;
+            instruction.setOperand(0, operation[1].num, operation[1].text);
+            instruction.setOperand(1, operation[2].num, operation[2].text);
+            instruction.setOperand(2, operation[3].num, operation[3].text);
+          } else if ("pos" in operation[3]) {
+            type = Formats.Jump;
 
-						// Check that the registers are in bounds
-						if (operation[1].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[1].pos,
-								"Operand 1 register number out of bounds",
-							);
-						}
-						if (operation[2].num > this._generalRegisters) {
-							throw new TokenError(
-								operation[2].pos,
-								"Operand 2 register number out of bounds",
-							);
-						}
+            // Check that the registers are in bounds
+            if (operation[1].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[1].pos,
+                "Operand 1 register number out of bounds"
+              );
+            }
+            if (operation[2].num > this._generalRegisters) {
+              throw new TokenError(
+                operation[2].pos,
+                "Operand 2 register number out of bounds"
+              );
+            }
 
-						instruction.setOperand(0, operation[1].num, operation[1].text);
-						instruction.setOperand(1, operation[2].num, operation[2].text);
-						instruction.setOperand(2, undefined, operation[3].text);
-					}
-				} else if (operation.length === 3) {
-					if (operation[1].type === RegType.FP) {
-						type = Formats.FloatingLoadStore;
-					} else {
-						type = Formats.GeneralLoadStore;
-					}
+            instruction.setOperand(0, operation[1].num, operation[1].text);
+            instruction.setOperand(1, operation[2].num, operation[2].text);
+            instruction.setOperand(2, undefined, operation[3].text);
+          }
+        } else if (operation.length === 3) {
+          if (operation[1].type === RegType.FP) {
+            type = Formats.FloatingLoadStore;
+          } else {
+            type = Formats.GeneralLoadStore;
+          }
 
-					// Check that the registers are in bounds
-					if (operation[1].num > this._generalRegisters) {
-						throw new TokenError(
-							operation[1].pos,
-							"Destiny register number out of bounds",
-						);
-					}
-					if (operation[2].reg.num > this._generalRegisters) {
-						throw new TokenError(
-							operation[2].reg.pos,
-							"Adress register number out of bounds",
-						);
-					}
-					if (operation[2].address > this._memorySize) {
-						throw new TokenError(
-							operation[2].reg.pos,
-							"Memory address out of bounds",
-						);
-					}
+          // Check that the registers are in bounds
+          if (operation[1].num > this._generalRegisters) {
+            throw new TokenError(
+              operation[1].pos,
+              "Destiny register number out of bounds"
+            );
+          }
+          if (operation[2].reg.num > this._generalRegisters) {
+            throw new TokenError(
+              operation[2].reg.pos,
+              "Adress register number out of bounds"
+            );
+          }
+          if (operation[2].address > this._memorySize) {
+            throw new TokenError(
+              operation[2].reg.pos,
+              "Memory address out of bounds"
+            );
+          }
 
-					instruction.setOperand(0, operation[1].num, operation[1].text);
-					instruction.setOperand(
-						1,
-						operation[2].address,
-						operation[2].address.toString(),
-					);
-					instruction.setOperand(
-						2,
-						operation[2].reg.num,
-						`(${operation[2].reg.text})`,
-					);
-				}
+          instruction.setOperand(0, operation[1].num, operation[1].text);
+          instruction.setOperand(
+            1,
+            operation[2].address,
+            operation[2].address.toString()
+          );
+          instruction.setOperand(
+            2,
+            operation[2].reg.num,
+            `(${operation[2].reg.text})`
+          );
+        }
 
-				const expectedType = opcodeToFormat(instruction.opcode);
-				if (type !== expectedType) {
-					//return fail(`Invalid instruction format for ${OpcodesNames[instruction.opcode]}. Expected ${FormatsNames[expectedType]} format, got ${FormatsNames[type]} format or similar`);
-					throw new TokenError(
-						pos,
-						`Invalid instruction format for ${
-							OpcodesNames[instruction.opcode]
-						}. Expected ${FormatsNames[expectedType]} format, got ${
-							FormatsNames[type]
-						} format or similar`,
-					);
-				}
+        const expectedType = opcodeToFormat(instruction.opcode);
+        if (type !== expectedType) {
+          //return fail(`Invalid instruction format for ${OpcodesNames[instruction.opcode]}. Expected ${FormatsNames[expectedType]} format, got ${FormatsNames[type]} format or similar`);
+          throw new TokenError(
+            pos,
+            `Invalid instruction format for ${
+              OpcodesNames[instruction.opcode]
+            }. Expected ${FormatsNames[expectedType]} format, got ${
+              FormatsNames[type]
+            } format or similar`
+          );
+        }
 
-				return instruction;
-			},
-		);
-	}
+        return instruction;
+      }
+    );
+  }
 }

--- a/src/core/Common/CodeParser.ts
+++ b/src/core/Common/CodeParser.ts
@@ -1,383 +1,383 @@
 import {
-  apply,
-  buildLexer,
-  expectEOF,
-  expectSingleResult,
-  rep_sc,
-  seq,
-  tok,
-  opt_sc,
-  type Token,
-  TokenError,
-  alt_sc,
-  fail,
-  type TokenPosition,
+	apply,
+	buildLexer,
+	expectEOF,
+	expectSingleResult,
+	rep_sc,
+	seq,
+	tok,
+	opt_sc,
+	type Token,
+	TokenError,
+	alt_sc,
+	fail,
+	type TokenPosition,
 } from "typescript-parsec";
 import { OpcodesNames, opcodeToFormat } from "./Opcodes";
 import { Formats, FormatsNames } from "./InstructionFormats";
 import { Instruction } from "./Instruction";
 
 enum Tokens {
-  Inmediate = 0,
-  RegFP = 1,
-  RegGP = 2,
-  Id = 3,
-  Label = 4,
-  BraketOpen = 5,
-  BraketClose = 6,
-  Number = 7,
-  Comma = 8,
-  Space = 9,
-  NewLine = 10,
-  Comment = 11,
+	Inmediate = 0,
+	RegFP = 1,
+	RegGP = 2,
+	Id = 3,
+	Label = 4,
+	BraketOpen = 5,
+	BraketClose = 6,
+	Number = 7,
+	Comma = 8,
+	Space = 9,
+	NewLine = 10,
+	Comment = 11,
 }
 
 enum RegType {
-  FP = 0,
-  GP = 1,
+	FP = 0,
+	GP = 1,
 }
 const RegTypeNames: string[] = ["FP", "GP"];
 
 interface Reg {
-  type: RegType;
-  pos: TokenPosition;
-  num: number;
-  text: string;
+	type: RegType;
+	pos: TokenPosition;
+	num: number;
+	text: string;
 }
 
 interface Address {
-  address: number;
-  reg: Reg;
+	address: number;
+	reg: Reg;
 }
 
 interface OpcodeToken {
-  opcode: number;
-  pos: TokenPosition;
+	opcode: number;
+	pos: TokenPosition;
 }
 
 const tokenizer = buildLexer([
-  [true, /^#[+-]?[0-9]+/g, Tokens.Inmediate],
-  [true, /^[Ff][0-9]+/g, Tokens.RegFP],
-  [true, /^[Rr][0-9]+/g, Tokens.RegGP],
-  [true, /^[A-Za-z][A-Za-z0-9]*\:/g, Tokens.Label],
-  [true, /^[A-Za-z][A-Za-z0-9]*/g, Tokens.Id],
-  [true, /^\(/g, Tokens.BraketOpen],
-  [true, /^\)/g, Tokens.BraketClose],
-  [true, /^[+-]?[0-9]+/g, Tokens.Number],
-  [false, /^\,/g, Tokens.Comma],
-  [false, /^[ \t\v\f]+/g, Tokens.Space],
-  [false, /^\n/g, Tokens.NewLine],
-  [false, /^\/\/.*\n/g, Tokens.Comment],
+	[true, /^#[+-]?[0-9]+/g, Tokens.Inmediate],
+	[true, /^[Ff][0-9]+/g, Tokens.RegFP],
+	[true, /^[Rr][0-9]+/g, Tokens.RegGP],
+	[true, /^[A-Za-z][A-Za-z0-9]*\:/g, Tokens.Label],
+	[true, /^[A-Za-z][A-Za-z0-9]*/g, Tokens.Id],
+	[true, /^\(/g, Tokens.BraketOpen],
+	[true, /^\)/g, Tokens.BraketClose],
+	[true, /^[+-]?[0-9]+/g, Tokens.Number],
+	[false, /^\,/g, Tokens.Comma],
+	[false, /^[ \t\v\f]+/g, Tokens.Space],
+	[false, /^\n/g, Tokens.NewLine],
+	[false, /^\/\/.*\n/g, Tokens.Comment],
 ]);
 
 const inmParser = apply(
-  tok(Tokens.Inmediate),
-  (num: Token<Tokens.Inmediate>) => {
-    return +num.text.slice(1);
-  }
+	tok(Tokens.Inmediate),
+	(num: Token<Tokens.Inmediate>) => {
+		return +num.text.slice(1);
+	},
 );
 
 const regParser = apply(
-  alt_sc(tok(Tokens.RegFP), tok(Tokens.RegGP)),
-  (reg: Token<Tokens.RegFP> | Token<Tokens.RegGP>) => {
-    let type = RegType.GP;
-    if (reg.kind === Tokens.RegFP) {
-      type = RegType.FP;
-    }
-    return {
-      type: type,
-      pos: reg.pos,
-      num: +reg.text.slice(1),
-      text: reg.text,
-    };
-  }
+	alt_sc(tok(Tokens.RegFP), tok(Tokens.RegGP)),
+	(reg: Token<Tokens.RegFP> | Token<Tokens.RegGP>) => {
+		let type = RegType.GP;
+		if (reg.kind === Tokens.RegFP) {
+			type = RegType.FP;
+		}
+		return {
+			type: type,
+			pos: reg.pos,
+			num: +reg.text.slice(1),
+			text: reg.text,
+		};
+	},
 );
 
 const addressParser = apply(
-  seq(
-    opt_sc(tok(Tokens.Number)),
-    tok(Tokens.BraketOpen),
-    regParser,
-    tok(Tokens.BraketClose)
-  ),
-  (
-    address: [
-      Token<Tokens.Number>,
-      Token<Tokens.BraketOpen>,
-      Reg,
-      Token<Tokens.BraketClose>
-    ]
-  ) => {
-    if (address[2].type === RegType.FP) {
-      throw new TokenError(
-        address[2].pos,
-        "Address register cannot be FP register"
-      );
-    }
-    return { address: address[0] ? +address[0].text : 0, reg: address[2] };
-  }
+	seq(
+		opt_sc(tok(Tokens.Number)),
+		tok(Tokens.BraketOpen),
+		regParser,
+		tok(Tokens.BraketClose),
+	),
+	(
+		address: [
+			Token<Tokens.Number>,
+			Token<Tokens.BraketOpen>,
+			Reg,
+			Token<Tokens.BraketClose>,
+		],
+	) => {
+		if (address[2].type === RegType.FP) {
+			throw new TokenError(
+				address[2].pos,
+				"Address register cannot be FP register",
+			);
+		}
+		return { address: address[0] ? +address[0].text : 0, reg: address[2] };
+	},
 );
 
 const opcodeParser = apply(
-  tok(Tokens.Id),
-  (opcodeTok: Token<Tokens.Id>): OpcodeToken => {
-    const opcode: number = OpcodesNames.indexOf(opcodeTok.text);
-    if (opcode !== -1) {
-      return { opcode: opcode, pos: opcodeTok.pos };
-    }
-    throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
-  }
+	tok(Tokens.Id),
+	(opcodeTok: Token<Tokens.Id>): OpcodeToken => {
+		const opcode: number = OpcodesNames.indexOf(opcodeTok.text);
+		if (opcode !== -1) {
+			return { opcode: opcode, pos: opcodeTok.pos };
+		}
+		throw new TokenError(opcodeTok.pos, `Unknown opcode ${opcodeTok.text}`);
+	},
 );
 
 export class CodeParser {
-  private _instructions: Instruction[] = [];
-  private _labels: { [k: string]: number } = {};
+	private _instructions: Instruction[] = [];
+	private _labels: { [k: string]: number } = {};
 
-  private _generalRegisters: number;
-  private _memorySize: number;
+	private _generalRegisters: number;
+	private _memorySize: number;
 
-  public get instructions(): Instruction[] {
-    return this._instructions;
-  }
+	public get instructions(): Instruction[] {
+		return this._instructions;
+	}
 
-  public get labels(): { [k: string]: number } {
-    return this._labels;
-  }
+	public get labels(): { [k: string]: number } {
+		return this._labels;
+	}
 
-  public get lines(): number {
-    return this._instructions.length;
-  }
+	public get lines(): number {
+		return this._instructions.length;
+	}
 
-  constructor(code: string, generalRegisters: number, memorySize: number) {
-    this._generalRegisters = generalRegisters;
-    this._memorySize = memorySize;
-    this.parse(code);
-  }
+	constructor(code: string, generalRegisters: number, memorySize: number) {
+		this._generalRegisters = generalRegisters;
+		this._memorySize = memorySize;
+		this.parse(code);
+	}
 
-  private parse(code: string) {
-    const result = expectSingleResult(
-      expectEOF(this.genCodeParser().parse(tokenizer.parse(code)))
-    );
+	private parse(code: string) {
+		const result = expectSingleResult(
+			expectEOF(this.genCodeParser().parse(tokenizer.parse(code))),
+		);
 
-    // Create labels and instructions
-    let pos = 0;
-    for (let i = 0; i < result[1].length; i++) {
-      const line = result[1][i];
-      if ("kind" in line && line.kind === Tokens.Label) {
-        const name = line.text.slice(0, -1);
-        if (name in this._labels) {
-          throw new Error(
-            `Error at instruction ${pos}, label ${line.text.slice(
-              0,
-              -1
-            )} already exists`
-          );
-        }
-        this._labels[name] = pos;
-      } else if (line instanceof Instruction) {
-        this._instructions.push(line);
-        pos++;
-      } else {
-        throw new Error(`Unexpected code parser fail: ${JSON.stringify(line)}`);
-      }
-    }
-  }
+		// Create labels and instructions
+		let pos = 0;
+		for (let i = 0; i < result[1].length; i++) {
+			const line = result[1][i];
+			if ("kind" in line && line.kind === Tokens.Label) {
+				const name = line.text.slice(0, -1);
+				if (name in this._labels) {
+					throw new Error(
+						`Error at instruction ${pos}, label ${line.text.slice(
+							0,
+							-1,
+						)} already exists`,
+					);
+				}
+				this._labels[name] = pos;
+			} else if (line instanceof Instruction) {
+				this._instructions.push(line);
+				pos++;
+			} else {
+				throw new Error(`Unexpected code parser fail: ${JSON.stringify(line)}`);
+			}
+		}
+	}
 
-  private genCodeParser() {
-    return seq(
-      opt_sc(tok(Tokens.Number)),
-      rep_sc(alt_sc(this.genOperationParser(), tok(Tokens.Label)))
-    );
-  }
+	private genCodeParser() {
+		return seq(
+			opt_sc(tok(Tokens.Number)),
+			rep_sc(alt_sc(this.genOperationParser(), tok(Tokens.Label))),
+		);
+	}
 
-  private genOperationParser() {
-    return apply(
-      alt_sc(
-        seq(opcodeParser, regParser, regParser, regParser),
-        seq(opcodeParser, regParser, regParser, inmParser),
-        seq(opcodeParser, regParser, regParser, tok(Tokens.Id)),
-        seq(opcodeParser, regParser, addressParser),
-        opcodeParser
-      ), // The order is important, the first succesfull match is the one that is returned
-      (
-        operation:
-          | OpcodeToken
-          | [OpcodeToken, Reg, Reg, Reg]
-          | [OpcodeToken, Reg, Reg, number]
-          | [OpcodeToken, Reg, Address]
-          | [OpcodeToken, Reg, Reg, Token<Tokens.Id>]
-      ) => {
-        let type: Formats;
-        const instruction: Instruction = new Instruction();
-        let pos: TokenPosition;
+	private genOperationParser() {
+		return apply(
+			alt_sc(
+				seq(opcodeParser, regParser, regParser, regParser),
+				seq(opcodeParser, regParser, regParser, inmParser),
+				seq(opcodeParser, regParser, regParser, tok(Tokens.Id)),
+				seq(opcodeParser, regParser, addressParser),
+				opcodeParser,
+			), // The order is important, the first succesfull match is the one that is returned
+			(
+				operation:
+					| OpcodeToken
+					| [OpcodeToken, Reg, Reg, Reg]
+					| [OpcodeToken, Reg, Reg, number]
+					| [OpcodeToken, Reg, Address]
+					| [OpcodeToken, Reg, Reg, Token<Tokens.Id>],
+			) => {
+				let type: Formats;
+				const instruction: Instruction = new Instruction();
+				let pos: TokenPosition;
 
-        // set the opcode and get the current position
-        if (Array.isArray(operation)) {
-          instruction.opcode = operation[0].opcode;
-          pos = operation[0].pos;
-        } else {
-          instruction.opcode = operation.opcode;
-          pos = operation.pos;
-        }
+				// set the opcode and get the current position
+				if (Array.isArray(operation)) {
+					instruction.opcode = operation[0].opcode;
+					pos = operation[0].pos;
+				} else {
+					instruction.opcode = operation.opcode;
+					pos = operation.pos;
+				}
 
-        // Check the recived instruction format and set the operands
-        if (!Array.isArray(operation)) {
-          type = Formats.Noop;
-        } else if ("num" in operation[2] && operation.length === 4) {
-          if (operation[2].type !== operation[1].type) {
-            throw new TokenError(
-              operation[2].pos,
-              `Second operand register type(${
-                RegTypeNames[operation[2].type]
-              }) mistmatch. Expected ${RegTypeNames[operation[1].type]}`
-            );
-          }
+				// Check the recived instruction format and set the operands
+				if (!Array.isArray(operation)) {
+					type = Formats.Noop;
+				} else if ("num" in operation[2] && operation.length === 4) {
+					if (operation[2].type !== operation[1].type) {
+						throw new TokenError(
+							operation[2].pos,
+							`Second operand register type(${
+								RegTypeNames[operation[2].type]
+							}) mistmatch. Expected ${RegTypeNames[operation[1].type]}`,
+						);
+					}
 
-          if (typeof operation[3] === "number") {
-            type = Formats.GeneralRegisterAndInmediate;
+					if (typeof operation[3] === "number") {
+						type = Formats.GeneralRegisterAndInmediate;
 
-            // Check that the registers are in bounds
-            if (operation[1].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[1].pos,
-                "Destiny register number out of bounds"
-              );
-            }
-            if (operation[2].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[2].pos,
-                "Operand 1 register number out of bounds"
-              );
-            }
+						// Check that the registers are in bounds
+						if (operation[1].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[1].pos,
+								"Destiny register number out of bounds",
+							);
+						}
+						if (operation[2].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[2].pos,
+								"Operand 1 register number out of bounds",
+							);
+						}
 
-            instruction.setOperand(0, operation[1].num, operation[1].text);
-            instruction.setOperand(1, operation[2].num, operation[2].text);
-            instruction.setOperand(
-              2,
-              operation[3],
-              `#${operation[3].toString()}`
-            );
-            if (operation[1].type === RegType.FP) {
-              throw new TokenError(
-                operation[1].pos,
-                "Inmediate operand not allowed for floating point registers"
-              );
-            }
-          } else if ("num" in operation[3]) {
-            if (operation[3].type !== operation[1].type) {
-              throw new TokenError(
-                operation[3].pos,
-                `Third operand register type(${
-                  RegTypeNames[operation[3].type]
-                }) mistmatch. Expected ${RegTypeNames[operation[1].type]}`
-              );
-            }
+						instruction.setOperand(0, operation[1].num, operation[1].text);
+						instruction.setOperand(1, operation[2].num, operation[2].text);
+						instruction.setOperand(
+							2,
+							operation[3],
+							`#${operation[3].toString()}`,
+						);
+						if (operation[1].type === RegType.FP) {
+							throw new TokenError(
+								operation[1].pos,
+								"Inmediate operand not allowed for floating point registers",
+							);
+						}
+					} else if ("num" in operation[3]) {
+						if (operation[3].type !== operation[1].type) {
+							throw new TokenError(
+								operation[3].pos,
+								`Third operand register type(${
+									RegTypeNames[operation[3].type]
+								}) mistmatch. Expected ${RegTypeNames[operation[1].type]}`,
+							);
+						}
 
-            if (operation[1].type === RegType.FP) {
-              type = Formats.TwoFloatingRegisters;
-            } else {
-              type = Formats.TwoGeneralRegisters;
-            }
+						if (operation[1].type === RegType.FP) {
+							type = Formats.TwoFloatingRegisters;
+						} else {
+							type = Formats.TwoGeneralRegisters;
+						}
 
-            // Check that the registers are in bounds
-            if (operation[1].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[1].pos,
-                "Destiny register number out of bounds"
-              );
-            }
-            if (operation[2].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[2].pos,
-                "Operand 1 register number out of bounds"
-              );
-            }
-            if (operation[3].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[3].pos,
-                "Operand 2 register number out of bounds"
-              );
-            }
+						// Check that the registers are in bounds
+						if (operation[1].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[1].pos,
+								"Destiny register number out of bounds",
+							);
+						}
+						if (operation[2].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[2].pos,
+								"Operand 1 register number out of bounds",
+							);
+						}
+						if (operation[3].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[3].pos,
+								"Operand 2 register number out of bounds",
+							);
+						}
 
-            instruction.setOperand(0, operation[1].num, operation[1].text);
-            instruction.setOperand(1, operation[2].num, operation[2].text);
-            instruction.setOperand(2, operation[3].num, operation[3].text);
-          } else if ("pos" in operation[3]) {
-            type = Formats.Jump;
+						instruction.setOperand(0, operation[1].num, operation[1].text);
+						instruction.setOperand(1, operation[2].num, operation[2].text);
+						instruction.setOperand(2, operation[3].num, operation[3].text);
+					} else if ("pos" in operation[3]) {
+						type = Formats.Jump;
 
-            // Check that the registers are in bounds
-            if (operation[1].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[1].pos,
-                "Operand 1 register number out of bounds"
-              );
-            }
-            if (operation[2].num > this._generalRegisters) {
-              throw new TokenError(
-                operation[2].pos,
-                "Operand 2 register number out of bounds"
-              );
-            }
+						// Check that the registers are in bounds
+						if (operation[1].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[1].pos,
+								"Operand 1 register number out of bounds",
+							);
+						}
+						if (operation[2].num > this._generalRegisters) {
+							throw new TokenError(
+								operation[2].pos,
+								"Operand 2 register number out of bounds",
+							);
+						}
 
-            instruction.setOperand(0, operation[1].num, operation[1].text);
-            instruction.setOperand(1, operation[2].num, operation[2].text);
-            instruction.setOperand(2, undefined, operation[3].text);
-          }
-        } else if (operation.length === 3) {
-          if (operation[1].type === RegType.FP) {
-            type = Formats.FloatingLoadStore;
-          } else {
-            type = Formats.GeneralLoadStore;
-          }
+						instruction.setOperand(0, operation[1].num, operation[1].text);
+						instruction.setOperand(1, operation[2].num, operation[2].text);
+						instruction.setOperand(2, undefined, operation[3].text);
+					}
+				} else if (operation.length === 3) {
+					if (operation[1].type === RegType.FP) {
+						type = Formats.FloatingLoadStore;
+					} else {
+						type = Formats.GeneralLoadStore;
+					}
 
-          // Check that the registers are in bounds
-          if (operation[1].num > this._generalRegisters) {
-            throw new TokenError(
-              operation[1].pos,
-              "Destiny register number out of bounds"
-            );
-          }
-          if (operation[2].reg.num > this._generalRegisters) {
-            throw new TokenError(
-              operation[2].reg.pos,
-              "Adress register number out of bounds"
-            );
-          }
-          if (operation[2].address > this._memorySize) {
-            throw new TokenError(
-              operation[2].reg.pos,
-              "Memory address out of bounds"
-            );
-          }
+					// Check that the registers are in bounds
+					if (operation[1].num > this._generalRegisters) {
+						throw new TokenError(
+							operation[1].pos,
+							"Destiny register number out of bounds",
+						);
+					}
+					if (operation[2].reg.num > this._generalRegisters) {
+						throw new TokenError(
+							operation[2].reg.pos,
+							"Adress register number out of bounds",
+						);
+					}
+					if (operation[2].address > this._memorySize) {
+						throw new TokenError(
+							operation[2].reg.pos,
+							"Memory address out of bounds",
+						);
+					}
 
-          instruction.setOperand(0, operation[1].num, operation[1].text);
-          instruction.setOperand(
-            1,
-            operation[2].address,
-            operation[2].address.toString()
-          );
-          instruction.setOperand(
-            2,
-            operation[2].reg.num,
-            `(${operation[2].reg.text})`
-          );
-        }
+					instruction.setOperand(0, operation[1].num, operation[1].text);
+					instruction.setOperand(
+						1,
+						operation[2].address,
+						operation[2].address.toString(),
+					);
+					instruction.setOperand(
+						2,
+						operation[2].reg.num,
+						`(${operation[2].reg.text})`,
+					);
+				}
 
-        const expectedType = opcodeToFormat(instruction.opcode);
-        if (type !== expectedType) {
-          //return fail(`Invalid instruction format for ${OpcodesNames[instruction.opcode]}. Expected ${FormatsNames[expectedType]} format, got ${FormatsNames[type]} format or similar`);
-          throw new TokenError(
-            pos,
-            `Invalid instruction format for ${
-              OpcodesNames[instruction.opcode]
-            }. Expected ${FormatsNames[expectedType]} format, got ${
-              FormatsNames[type]
-            } format or similar`
-          );
-        }
+				const expectedType = opcodeToFormat(instruction.opcode);
+				if (type !== expectedType) {
+					//return fail(`Invalid instruction format for ${OpcodesNames[instruction.opcode]}. Expected ${FormatsNames[expectedType]} format, got ${FormatsNames[type]} format or similar`);
+					throw new TokenError(
+						pos,
+						`Invalid instruction format for ${
+							OpcodesNames[instruction.opcode]
+						}. Expected ${FormatsNames[expectedType]} format, got ${
+							FormatsNames[type]
+						} format or similar`,
+					);
+				}
 
-        return instruction;
-      }
-    );
-  }
+				return instruction;
+			},
+		);
+	}
 }

--- a/src/core/Common/CodeParser.ts
+++ b/src/core/Common/CodeParser.ts
@@ -186,7 +186,7 @@ export class CodeParser {
 
   private genCodeParser() {
     return seq(
-      tok(Tokens.Number),
+      opt_sc(tok(Tokens.Number)),
       rep_sc(alt_sc(this.genOperationParser(), tok(Tokens.Label)))
     );
   }

--- a/src/core/VLIW/VLIWCode.ts
+++ b/src/core/VLIW/VLIWCode.ts
@@ -1,74 +1,74 @@
-import { LargeInstruction } from './LargeInstructions';
-import { VLIWOperation } from './VLIWOperation';
-import { Code } from '../Common/Code';
-import { Parse, ExportAsString } from './VLIWParser';
+import type { Code } from "@/core/Common/Code";
+import { LargeInstruction } from "./LargeInstructions";
+import type { VLIWOperation } from "./VLIWOperation";
+import { ExportAsString, Parse } from "./VLIWParser";
 
 export class VLIWCode {
-    public instructions: LargeInstruction[];
+  public instructions: LargeInstruction[];
 
-    private _largeInstructionNumber: number;
-    private _superescalarCode: Code;
+  private _largeInstructionNumber: number;
+  private _superescalarCode: Code;
 
-    constructor(n?: number) {
-        if (n) {
-            this.instructions = new Array(n);
-            this.instructions.fill(new LargeInstruction());
-        } else {
-            this.instructions = [];
-        }
-        this._largeInstructionNumber = 0;
+  constructor(n?: number) {
+    if (n) {
+      this.instructions = new Array(n);
+      this.instructions.fill(new LargeInstruction());
+    } else {
+      this.instructions = [];
     }
+    this._largeInstructionNumber = 0;
+  }
 
-    // Getters
-    public getLargeInstructionNumber(): number {
-        return this._largeInstructionNumber;
-    }
+  // Getters
+  public getLargeInstructionNumber(): number {
+    return this._largeInstructionNumber;
+  }
 
-    public getLargeInstruction(index: number): LargeInstruction {
-        if ((index < 0) || (index >= this._largeInstructionNumber)) {
-            return null;
-        }
-        return this.instructions[index];
+  public getLargeInstruction(index: number): LargeInstruction {
+    if (index < 0 || index >= this._largeInstructionNumber) {
+      return null;
     }
+    return this.instructions[index];
+  }
 
-    public getBreakPoint(index: number): boolean {
-        return this.instructions[index].getBreakPoint();
-    }
+  public getBreakPoint(index: number): boolean {
+    return this.instructions[index].getBreakPoint();
+  }
 
-    // Setters
-    public setInstructionNumber(index: number) {
-        this.instructions = new Array<LargeInstruction>(index);
-        this._largeInstructionNumber = index;
-    }
+  // Setters
+  public setInstructionNumber(index: number) {
+    this.instructions = new Array<LargeInstruction>(index);
+    this._largeInstructionNumber = index;
+  }
 
-    public setBreakPoint(index: number, b: boolean) {
-        this.instructions[index].setBreakPoint(b);
-    }
+  public setBreakPoint(index: number, b: boolean) {
+    this.instructions[index].setBreakPoint(b);
+  }
 
-    public addOperacion(index: number, oper: VLIWOperation) {
-        this.instructions[index].addOperation(oper);
-    }
+  public addOperacion(index: number, oper: VLIWOperation) {
+    this.instructions[index].addOperation(oper);
+  }
 
-    public get superescalarCode(): Code {
-        return this._superescalarCode;
-    }
+  public get superescalarCode(): Code {
+    return this._superescalarCode;
+  }
 
-    public set superescalarCode(code: Code) {
-        this._superescalarCode = code;
-    }
+  public set superescalarCode(code: Code) {
+    this._superescalarCode = code;
+  }
 
-    public clear() {
-        this.instructions = null;
-        this._largeInstructionNumber = 0;
-    }
+  public clear() {
+    this.instructions = null;
+    this._largeInstructionNumber = 0;
+  }
 
-    public save(): string {
-        return ExportAsString(this._largeInstructionNumber, this.instructions);
-    }
+  public save(): string {
+    return ExportAsString(this._largeInstructionNumber, this.instructions);
+  }
 
-    public load(input: string, code: Code): void {
-        this.instructions = Parse(input, code);
-        this._largeInstructionNumber = this.instructions.length;
-        this._superescalarCode = code;
-    }
+  public load(input: string, code: Code): void {
+    this.instructions = Parse(input, code);
+    this._largeInstructionNumber = this.instructions.length;
+    this._superescalarCode = code;
+  }
 }

--- a/src/core/VLIW/VLIWCode.ts
+++ b/src/core/VLIW/VLIWCode.ts
@@ -1,7 +1,7 @@
 import { LargeInstruction } from './LargeInstructions';
 import { VLIWOperation } from './VLIWOperation';
 import { Code } from '../Common/Code';
-import { VLIWParser } from './VLIWParser';
+import { Parse, ExportAsString } from './VLIWParser';
 
 export class VLIWCode {
     public instructions: LargeInstruction[];
@@ -63,11 +63,11 @@ export class VLIWCode {
     }
 
     public save(): string {
-        return VLIWParser.ExportAsString(this._largeInstructionNumber, this.instructions);
+        return ExportAsString(this._largeInstructionNumber, this.instructions);
     }
 
     public load(input: string, code: Code): void {
-        this.instructions = VLIWParser.Parse(input, code);
+        this.instructions = Parse(input, code);
         this._largeInstructionNumber = this.instructions.length;
         this._superescalarCode = code;
     }

--- a/src/core/VLIW/VLIWParser.ts
+++ b/src/core/VLIW/VLIWParser.ts
@@ -1,208 +1,208 @@
 import {
-	apply,
-	buildLexer,
-	expectEOF,
-	expectSingleResult,
-	rep_sc,
-	rep_n,
-	seq,
-	tok,
-	combine,
-	opt_sc,
-	type Token,
-	TokenError,
-	list_sc,
+  apply,
+  buildLexer,
+  expectEOF,
+  expectSingleResult,
+  rep_sc,
+  rep_n,
+  seq,
+  tok,
+  combine,
+  opt_sc,
+  type Token,
+  TokenError,
+  list_sc,
 } from "typescript-parsec";
 import { LargeInstruction } from "./LargeInstructions";
 import type { Code } from "../Common/Code";
 import { VLIWOperation } from "./VLIWOperation";
 import {
-	type FunctionalUnitType,
-	FunctionalUnitTypeNames,
-	FUNCTIONALUNITTYPESQUANTITY,
+  type FunctionalUnitType,
+  FunctionalUnitTypeNames,
+  FUNCTIONALUNITTYPESQUANTITY,
 } from "../Common/FunctionalUnit";
 
 enum Tokens {
-	Number = 0,
-	Comma = 1,
-	Space = 2,
-	NewLine = 3,
-	Comment = 4,
+  Number = 0,
+  Comma = 1,
+  Space = 2,
+  NewLine = 3,
+  Comment = 4,
 }
 
 const tokenizer = buildLexer([
-	[true, /^[0-9]+/g, Tokens.Number],
-	[true, /^\n+/g, Tokens.NewLine],
-	[false, /^\,/g, Tokens.Comma],
-	[false, /^[ \t\v\f]+/g, Tokens.Space],
-	[false, /^\/\/.*\n/g, Tokens.Comment],
+  [true, /^[0-9]+/g, Tokens.Number],
+  [true, /^\n+/g, Tokens.NewLine],
+  [false, /^\,/g, Tokens.Comma],
+  [false, /^[ \t\v\f]+/g, Tokens.Space],
+  [false, /^\/\/.*\n/g, Tokens.Comment],
 ]);
 
 const functionalUnitTypeParser = apply(
-	tok(Tokens.Number),
-	(num: Token<Tokens.Number>): FunctionalUnitType => {
-		const type = +num.text;
-		if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
-			throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
-		}
-		return type;
-	},
+  tok(Tokens.Number),
+  (num: Token<Tokens.Number>): FunctionalUnitType => {
+    const type = +num.text;
+    if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
+      throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
+    }
+    return type;
+  }
 );
 
 interface IndexParsed {
-	index: number;
-	isJump: boolean;
-	functionalUnitType: FunctionalUnitType;
+  index: number;
+  isJump: boolean;
+  functionalUnitType: FunctionalUnitType;
 }
 
 export function Parse(input: string, code: Code): LargeInstruction[] {
-	// This parses depends on the code, so we moved it here
-	const indexParser = apply(
-		tok(Tokens.Number),
-		(num: Token<Tokens.Number>): IndexParsed => {
-			const index = +num.text;
-			// Check if index is not out of bounds
-			if (index >= code.instructions.length) {
-				throw new TokenError(num.pos, `Invalid index ${index}`);
-			}
-			return {
-				index: index,
-				isJump: code.instructions[index].isJumpInstruction(),
-				functionalUnitType: code.instructions[index].getFunctionalUnitType(),
-			};
-		},
-	);
+  // This parses depends on the code, so we moved it here
+  const indexParser = apply(
+    tok(Tokens.Number),
+    (num: Token<Tokens.Number>): IndexParsed => {
+      const index = +num.text;
+      // Check if index is not out of bounds
+      if (index >= code.instructions.length) {
+        throw new TokenError(num.pos, `Invalid index ${index}`);
+      }
+      return {
+        index: index,
+        isJump: code.instructions[index].isJumpInstruction(),
+        functionalUnitType: code.instructions[index].getFunctionalUnitType(),
+      };
+    }
+  );
 
-	// This other parsers depends on the previous one, so we need to declare it here also
+  // This other parsers depends on the previous one, so we need to declare it here also
 
-	let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
-	const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
-		currentIndex = indexParsed;
-		const numOfElements = indexParsed.isJump ? 5 : 2;
-		return seq(
-			functionalUnitTypeParser,
-			rep_n(tok(Tokens.Number), numOfElements),
-		);
-	});
+  let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
+  const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
+    currentIndex = indexParsed;
+    const numOfElements = indexParsed.isJump ? 5 : 2;
+    return seq(
+      functionalUnitTypeParser,
+      rep_n(tok(Tokens.Number), numOfElements)
+    );
+  });
 
-	const operationParser = apply(
-		operationCombiner,
-		(componets: [FunctionalUnitType, Token<Tokens>[]]) => {
-			// Check if we received the right amount of operands
-			if (componets[1].length < 2) {
-				throw new TokenError(
-					componets[1][0].pos,
-					`Expected at least 2 operands, received ${componets[1].length}`,
-				);
-			}
+  const operationParser = apply(
+    operationCombiner,
+    (componets: [FunctionalUnitType, Token<Tokens>[]]) => {
+      // Check if we received the right amount of operands
+      if (componets[1].length < 2) {
+        throw new TokenError(
+          componets[1][0].pos,
+          `Expected at least 2 operands, received ${componets[1].length}`
+        );
+      }
 
-			const index = +currentIndex.index;
-			const functionalUnitType = componets[0];
-			const functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
-			const predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
+      const index = +currentIndex.index;
+      const functionalUnitType = componets[0];
+      const functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
+      const predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
 
-			// Check if the recived functional unit type is the same as the one in the code
-			if (functionalUnitType !== currentIndex.functionalUnitType) {
-				throw new TokenError(
-					componets[1][0].pos,
-					`Invalid functional unit type ${
-						FunctionalUnitTypeNames[functionalUnitType]
-					} for instruction ${index}(expected ${
-						FunctionalUnitTypeNames[currentIndex.functionalUnitType]
-					})`,
-				);
-			}
+      // Check if the recived functional unit type is the same as the one in the code
+      if (functionalUnitType !== currentIndex.functionalUnitType) {
+        throw new TokenError(
+          componets[1][0].pos,
+          `Invalid functional unit type ${
+            FunctionalUnitTypeNames[functionalUnitType]
+          } for instruction ${index}(expected ${
+            FunctionalUnitTypeNames[currentIndex.functionalUnitType]
+          })`
+        );
+      }
 
-			const operation = new VLIWOperation(
-				null,
-				code.instructions[index],
-				functionalUnitType,
-				functionalUnitIndex,
-			);
-			operation.setPred(predicate);
+      const operation = new VLIWOperation(
+        null,
+        code.instructions[index],
+        functionalUnitType,
+        functionalUnitIndex
+      );
+      operation.setPred(predicate);
 
-			if (currentIndex.isJump) {
-				// Check if we received the right amount of operands
-				if (componets[1].length !== 5) {
-					throw new TokenError(
-						componets[1][componets[1].length - 1].pos,
-						`Expected 5 operands(Jump operation), received ${componets[1].length}`,
-					);
-				}
-				const destiny = +componets[1][2].text;
-				const predTrue = +componets[1][3].text;
-				const predFalse = +componets[1][4].text;
+      if (currentIndex.isJump) {
+        // Check if we received the right amount of operands
+        if (componets[1].length !== 5) {
+          throw new TokenError(
+            componets[1][componets[1].length - 1].pos,
+            `Expected 5 operands(Jump operation), received ${componets[1].length}`
+          );
+        }
+        const destiny = +componets[1][2].text;
+        const predTrue = +componets[1][3].text;
+        const predFalse = +componets[1][4].text;
 
-				operation.setOperand(2, destiny, "");
-				operation.setPredTrue(predTrue);
-				operation.setPredFalse(predFalse);
-			}
-			return operation;
-		},
-	);
+        operation.setOperand(2, destiny, "");
+        operation.setPredTrue(predTrue);
+        operation.setPredFalse(predFalse);
+      }
+      return operation;
+    }
+  );
 
-	const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
-	const programParser = seq(
-		opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
-		list_sc(lineParser, tok(Tokens.NewLine)),
-		opt_sc(tok(Tokens.NewLine)),
-	);
+  const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
+  const programParser = seq(
+    opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
+    list_sc(lineParser, tok(Tokens.NewLine)),
+    opt_sc(tok(Tokens.NewLine))
+  );
 
-	// Lets parse the input
-	const result = expectSingleResult(
-		expectEOF(programParser.parse(tokenizer.parse(input))),
-	);
+  // Lets parse the input
+  const result = expectSingleResult(
+    expectEOF(programParser.parse(tokenizer.parse(input)))
+  );
 
-	//let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
-	const instructions: LargeInstruction[] = new Array<LargeInstruction>(
-		result[1].length,
-	);
-	const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
+  //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
+  const instructions: LargeInstruction[] = new Array<LargeInstruction>(
+    result[1].length
+  );
+  const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
 
-	for (let i = 0; i < instructionsLines.length; i++) {
-		instructions[i] = new LargeInstruction();
+  for (let i = 0; i < instructionsLines.length; i++) {
+    instructions[i] = new LargeInstruction();
 
-		// Iterate over the operations
-		for (const operation of instructionsLines[i][1]) {
-			instructions[i].addOperation(operation);
-		}
-	}
+    // Iterate over the operations
+    for (const operation of instructionsLines[i][1]) {
+      instructions[i].addOperation(operation);
+    }
+  }
 
-	return instructions;
+  return instructions;
 }
 
 export function ExportAsString(
-	_instructionNumber: number,
-	_instructions: LargeInstruction[],
+  _instructionNumber: number,
+  _instructions: LargeInstruction[]
 ): string {
-	let outputString: string;
-	outputString += _instructionNumber;
+  let outputString: string;
+  outputString += _instructionNumber;
 
-	for (let i = 0; i < _instructionNumber; i++) {
-		const operationAmount = _instructions[i].getVLIWOperationsNumber();
-		outputString += operationAmount;
+  for (let i = 0; i < _instructionNumber; i++) {
+    const operationAmount = _instructions[i].getVLIWOperationsNumber();
+    outputString += operationAmount;
 
-		for (let j = 0; j < operationAmount; j++) {
-			const operation = _instructions[i].getOperation(j);
-			outputString += "\t";
-			outputString += operation.id;
-			outputString += " ";
-			outputString += operation.getFunctionalUnitType();
-			outputString += " ";
-			outputString += operation.getFunctionalUnitType();
-			outputString += " ";
-			outputString += operation.getPred();
+    for (let j = 0; j < operationAmount; j++) {
+      const operation = _instructions[i].getOperation(j);
+      outputString += "\t";
+      outputString += operation.id;
+      outputString += " ";
+      outputString += operation.getFunctionalUnitType();
+      outputString += " ";
+      outputString += operation.getFunctionalUnitType();
+      outputString += " ";
+      outputString += operation.getPred();
 
-			if (operation.isJumpInstruction()) {
-				outputString += " ";
-				outputString += operation.getOperand(2);
-				outputString += " ";
-				outputString += operation.getPredTrue();
-				outputString += " ";
-				outputString += operation.getPredFalse();
-			}
-		}
-		outputString += "\n";
-	}
-	return outputString;
+      if (operation.isJumpInstruction()) {
+        outputString += " ";
+        outputString += operation.getOperand(2);
+        outputString += " ";
+        outputString += operation.getPredTrue();
+        outputString += " ";
+        outputString += operation.getPredFalse();
+      }
+    }
+    outputString += "\n";
+  }
+  return outputString;
 }

--- a/src/core/VLIW/VLIWParser.ts
+++ b/src/core/VLIW/VLIWParser.ts
@@ -1,208 +1,208 @@
 import {
-  apply,
-  buildLexer,
-  expectEOF,
-  expectSingleResult,
-  rep_sc,
-  rep_n,
-  seq,
-  tok,
-  combine,
-  opt_sc,
-  type Token,
-  TokenError,
-  list_sc,
+	apply,
+	buildLexer,
+	expectEOF,
+	expectSingleResult,
+	rep_sc,
+	rep_n,
+	seq,
+	tok,
+	combine,
+	opt_sc,
+	type Token,
+	TokenError,
+	list_sc,
 } from "typescript-parsec";
 import { LargeInstruction } from "./LargeInstructions";
 import type { Code } from "../Common/Code";
 import { VLIWOperation } from "./VLIWOperation";
 import {
-  type FunctionalUnitType,
-  FunctionalUnitTypeNames,
-  FUNCTIONALUNITTYPESQUANTITY,
+	type FunctionalUnitType,
+	FunctionalUnitTypeNames,
+	FUNCTIONALUNITTYPESQUANTITY,
 } from "../Common/FunctionalUnit";
 
 enum Tokens {
-  Number = 0,
-  Comma = 1,
-  Space = 2,
-  NewLine = 3,
-  Comment = 4,
+	Number = 0,
+	Comma = 1,
+	Space = 2,
+	NewLine = 3,
+	Comment = 4,
 }
 
 const tokenizer = buildLexer([
-  [true, /^[0-9]+/g, Tokens.Number],
-  [true, /^\n+/g, Tokens.NewLine],
-  [false, /^\,/g, Tokens.Comma],
-  [false, /^[ \t\v\f]+/g, Tokens.Space],
-  [false, /^\/\/.*\n/g, Tokens.Comment],
+	[true, /^[0-9]+/g, Tokens.Number],
+	[true, /^\n+/g, Tokens.NewLine],
+	[false, /^\,/g, Tokens.Comma],
+	[false, /^[ \t\v\f]+/g, Tokens.Space],
+	[false, /^\/\/.*\n/g, Tokens.Comment],
 ]);
 
 const functionalUnitTypeParser = apply(
-  tok(Tokens.Number),
-  (num: Token<Tokens.Number>): FunctionalUnitType => {
-    const type = +num.text;
-    if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
-      throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
-    }
-    return type;
-  }
+	tok(Tokens.Number),
+	(num: Token<Tokens.Number>): FunctionalUnitType => {
+		const type = +num.text;
+		if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
+			throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
+		}
+		return type;
+	},
 );
 
 interface IndexParsed {
-  index: number;
-  isJump: boolean;
-  functionalUnitType: FunctionalUnitType;
+	index: number;
+	isJump: boolean;
+	functionalUnitType: FunctionalUnitType;
 }
 
 export function Parse(input: string, code: Code): LargeInstruction[] {
-  // This parses depends on the code, so we moved it here
-  const indexParser = apply(
-    tok(Tokens.Number),
-    (num: Token<Tokens.Number>): IndexParsed => {
-      const index = +num.text;
-      // Check if index is not out of bounds
-      if (index >= code.instructions.length) {
-        throw new TokenError(num.pos, `Invalid index ${index}`);
-      }
-      return {
-        index: index,
-        isJump: code.instructions[index].isJumpInstruction(),
-        functionalUnitType: code.instructions[index].getFunctionalUnitType(),
-      };
-    }
-  );
+	// This parses depends on the code, so we moved it here
+	const indexParser = apply(
+		tok(Tokens.Number),
+		(num: Token<Tokens.Number>): IndexParsed => {
+			const index = +num.text;
+			// Check if index is not out of bounds
+			if (index >= code.instructions.length) {
+				throw new TokenError(num.pos, `Invalid index ${index}`);
+			}
+			return {
+				index: index,
+				isJump: code.instructions[index].isJumpInstruction(),
+				functionalUnitType: code.instructions[index].getFunctionalUnitType(),
+			};
+		},
+	);
 
-  // This other parsers depends on the previous one, so we need to declare it here also
+	// This other parsers depends on the previous one, so we need to declare it here also
 
-  let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
-  const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
-    currentIndex = indexParsed;
-    const numOfElements = indexParsed.isJump ? 5 : 2;
-    return seq(
-      functionalUnitTypeParser,
-      rep_n(tok(Tokens.Number), numOfElements)
-    );
-  });
+	let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
+	const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
+		currentIndex = indexParsed;
+		const numOfElements = indexParsed.isJump ? 5 : 2;
+		return seq(
+			functionalUnitTypeParser,
+			rep_n(tok(Tokens.Number), numOfElements),
+		);
+	});
 
-  const operationParser = apply(
-    operationCombiner,
-    (componets: [FunctionalUnitType, Token<Tokens>[]]) => {
-      // Check if we received the right amount of operands
-      if (componets[1].length < 2) {
-        throw new TokenError(
-          componets[1][0].pos,
-          `Expected at least 2 operands, received ${componets[1].length}`
-        );
-      }
+	const operationParser = apply(
+		operationCombiner,
+		(componets: [FunctionalUnitType, Token<Tokens>[]]) => {
+			// Check if we received the right amount of operands
+			if (componets[1].length < 2) {
+				throw new TokenError(
+					componets[1][0].pos,
+					`Expected at least 2 operands, received ${componets[1].length}`,
+				);
+			}
 
-      const index = +currentIndex.index;
-      const functionalUnitType = componets[0];
-      const functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
-      const predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
+			const index = +currentIndex.index;
+			const functionalUnitType = componets[0];
+			const functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
+			const predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
 
-      // Check if the recived functional unit type is the same as the one in the code
-      if (functionalUnitType !== currentIndex.functionalUnitType) {
-        throw new TokenError(
-          componets[1][0].pos,
-          `Invalid functional unit type ${
-            FunctionalUnitTypeNames[functionalUnitType]
-          } for instruction ${index}(expected ${
-            FunctionalUnitTypeNames[currentIndex.functionalUnitType]
-          })`
-        );
-      }
+			// Check if the recived functional unit type is the same as the one in the code
+			if (functionalUnitType !== currentIndex.functionalUnitType) {
+				throw new TokenError(
+					componets[1][0].pos,
+					`Invalid functional unit type ${
+						FunctionalUnitTypeNames[functionalUnitType]
+					} for instruction ${index}(expected ${
+						FunctionalUnitTypeNames[currentIndex.functionalUnitType]
+					})`,
+				);
+			}
 
-      const operation = new VLIWOperation(
-        null,
-        code.instructions[index],
-        functionalUnitType,
-        functionalUnitIndex
-      );
-      operation.setPred(predicate);
+			const operation = new VLIWOperation(
+				null,
+				code.instructions[index],
+				functionalUnitType,
+				functionalUnitIndex,
+			);
+			operation.setPred(predicate);
 
-      if (currentIndex.isJump) {
-        // Check if we received the right amount of operands
-        if (componets[1].length !== 5) {
-          throw new TokenError(
-            componets[1][componets[1].length - 1].pos,
-            `Expected 5 operands(Jump operation), received ${componets[1].length}`
-          );
-        }
-        const destiny = +componets[1][2].text;
-        const predTrue = +componets[1][3].text;
-        const predFalse = +componets[1][4].text;
+			if (currentIndex.isJump) {
+				// Check if we received the right amount of operands
+				if (componets[1].length !== 5) {
+					throw new TokenError(
+						componets[1][componets[1].length - 1].pos,
+						`Expected 5 operands(Jump operation), received ${componets[1].length}`,
+					);
+				}
+				const destiny = +componets[1][2].text;
+				const predTrue = +componets[1][3].text;
+				const predFalse = +componets[1][4].text;
 
-        operation.setOperand(2, destiny, "");
-        operation.setPredTrue(predTrue);
-        operation.setPredFalse(predFalse);
-      }
-      return operation;
-    }
-  );
+				operation.setOperand(2, destiny, "");
+				operation.setPredTrue(predTrue);
+				operation.setPredFalse(predFalse);
+			}
+			return operation;
+		},
+	);
 
-  const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
-  const programParser = seq(
-    opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
-    list_sc(lineParser, tok(Tokens.NewLine)),
-    opt_sc(tok(Tokens.NewLine))
-  );
+	const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
+	const programParser = seq(
+		opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
+		list_sc(lineParser, tok(Tokens.NewLine)),
+		opt_sc(tok(Tokens.NewLine)),
+	);
 
-  // Lets parse the input
-  const result = expectSingleResult(
-    expectEOF(programParser.parse(tokenizer.parse(input)))
-  );
+	// Lets parse the input
+	const result = expectSingleResult(
+		expectEOF(programParser.parse(tokenizer.parse(input))),
+	);
 
-  //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
-  const instructions: LargeInstruction[] = new Array<LargeInstruction>(
-    result[1].length
-  );
-  const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
+	//let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
+	const instructions: LargeInstruction[] = new Array<LargeInstruction>(
+		result[1].length,
+	);
+	const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
 
-  for (let i = 0; i < instructionsLines.length; i++) {
-    instructions[i] = new LargeInstruction();
+	for (let i = 0; i < instructionsLines.length; i++) {
+		instructions[i] = new LargeInstruction();
 
-    // Iterate over the operations
-    for (const operation of instructionsLines[i][1]) {
-      instructions[i].addOperation(operation);
-    }
-  }
+		// Iterate over the operations
+		for (const operation of instructionsLines[i][1]) {
+			instructions[i].addOperation(operation);
+		}
+	}
 
-  return instructions;
+	return instructions;
 }
 
 export function ExportAsString(
-  _instructionNumber: number,
-  _instructions: LargeInstruction[]
+	_instructionNumber: number,
+	_instructions: LargeInstruction[],
 ): string {
-  let outputString: string;
-  outputString += _instructionNumber;
+	let outputString: string;
+	outputString += _instructionNumber;
 
-  for (let i = 0; i < _instructionNumber; i++) {
-    const operationAmount = _instructions[i].getVLIWOperationsNumber();
-    outputString += operationAmount;
+	for (let i = 0; i < _instructionNumber; i++) {
+		const operationAmount = _instructions[i].getVLIWOperationsNumber();
+		outputString += operationAmount;
 
-    for (let j = 0; j < operationAmount; j++) {
-      const operation = _instructions[i].getOperation(j);
-      outputString += "\t";
-      outputString += operation.id;
-      outputString += " ";
-      outputString += operation.getFunctionalUnitType();
-      outputString += " ";
-      outputString += operation.getFunctionalUnitType();
-      outputString += " ";
-      outputString += operation.getPred();
+		for (let j = 0; j < operationAmount; j++) {
+			const operation = _instructions[i].getOperation(j);
+			outputString += "\t";
+			outputString += operation.id;
+			outputString += " ";
+			outputString += operation.getFunctionalUnitType();
+			outputString += " ";
+			outputString += operation.getFunctionalUnitType();
+			outputString += " ";
+			outputString += operation.getPred();
 
-      if (operation.isJumpInstruction()) {
-        outputString += " ";
-        outputString += operation.getOperand(2);
-        outputString += " ";
-        outputString += operation.getPredTrue();
-        outputString += " ";
-        outputString += operation.getPredFalse();
-      }
-    }
-    outputString += "\n";
-  }
-  return outputString;
+			if (operation.isJumpInstruction()) {
+				outputString += " ";
+				outputString += operation.getOperand(2);
+				outputString += " ";
+				outputString += operation.getPredTrue();
+				outputString += " ";
+				outputString += operation.getPredFalse();
+			}
+		}
+		outputString += "\n";
+	}
+	return outputString;
 }

--- a/src/core/VLIW/VLIWParser.ts
+++ b/src/core/VLIW/VLIWParser.ts
@@ -1,164 +1,208 @@
-import { apply, buildLexer, expectEOF, expectSingleResult, rep_sc, rep_n, seq, tok, combine, opt_sc, Token, TokenError, list_sc } from 'typescript-parsec';
-import { LargeInstruction } from './LargeInstructions';
-import { Code } from '../Common/Code';
-import { VLIWOperation } from './VLIWOperation';
-import { FunctionalUnitType, FunctionalUnitTypeNames, FUNCTIONALUNITTYPESQUANTITY } from '../Common/FunctionalUnit';
+import {
+  apply,
+  buildLexer,
+  expectEOF,
+  expectSingleResult,
+  rep_sc,
+  rep_n,
+  seq,
+  tok,
+  combine,
+  opt_sc,
+  type Token,
+  TokenError,
+  list_sc,
+} from "typescript-parsec";
+import { LargeInstruction } from "./LargeInstructions";
+import type { Code } from "../Common/Code";
+import { VLIWOperation } from "./VLIWOperation";
+import {
+  type FunctionalUnitType,
+  FunctionalUnitTypeNames,
+  FUNCTIONALUNITTYPESQUANTITY,
+} from "../Common/FunctionalUnit";
 
 enum Tokens {
-    Number,
-    Comma,
-    Space,
-    NewLine,
-    Comment
+  Number = 0,
+  Comma = 1,
+  Space = 2,
+  NewLine = 3,
+  Comment = 4,
 }
 
 const tokenizer = buildLexer([
-    [true, /^[0-9]+/g, Tokens.Number],
-    [true, /^\n+/g, Tokens.NewLine],
-    [false, /^\,/g, Tokens.Comma],
-    [false, /^[ \t\v\f]+/g, Tokens.Space],
-    [false, /^\/\/.*\n/g, Tokens.Comment]
+  [true, /^[0-9]+/g, Tokens.Number],
+  [true, /^\n+/g, Tokens.NewLine],
+  [false, /^\,/g, Tokens.Comma],
+  [false, /^[ \t\v\f]+/g, Tokens.Space],
+  [false, /^\/\/.*\n/g, Tokens.Comment],
 ]);
 
 const functionalUnitTypeParser = apply(
-    tok(Tokens.Number),
-    (num: Token<Tokens.Number>): FunctionalUnitType => {
-        let type = +num.text;
-        if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
-            throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
-        }
-        return type;
+  tok(Tokens.Number),
+  (num: Token<Tokens.Number>): FunctionalUnitType => {
+    const type = +num.text;
+    if (type > FUNCTIONALUNITTYPESQUANTITY - 1) {
+      throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
     }
+    return type;
+  }
 );
 
 interface IndexParsed {
-    index: number;
-    isJump: boolean;
-    functionalUnitType: FunctionalUnitType;
+  index: number;
+  isJump: boolean;
+  functionalUnitType: FunctionalUnitType;
 }
 
-
-export class VLIWParser {
-
-    public static Parse(input: string, code: Code): LargeInstruction[] {
-
-        // This parses depends on the code, so we moved it here
-        const indexParser = apply(
-            tok(Tokens.Number),
-            (num: Token<Tokens.Number>): IndexParsed => {
-                let index = +num.text;
-                // Check if index is not out of bounds
-                if (index >= code.instructions.length) {
-                    throw new TokenError(num.pos, `Invalid index ${index}`);
-                }
-                return { index: index, isJump: code.instructions[index].isJumpInstruction(), functionalUnitType: code.instructions[index].getFunctionalUnitType() };
-            }
-        );
-
-        // This other parsers depends on the previous one, so we need to declare it here also
-
-        let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
-        const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
-            currentIndex = indexParsed;
-            let numOfElements = indexParsed.isJump ? 5 : 2;
-            return seq(functionalUnitTypeParser, rep_n(tok(Tokens.Number), numOfElements));
-        });
-
-        const operationParser = apply(
-            operationCombiner,
-            (componets: [FunctionalUnitType, Token<Tokens>[]]) => {
-                // Check if we received the right amount of operands
-                if (componets[1].length < 2) {
-                    throw new TokenError(componets[1][0].pos, `Expected at least 2 operands, received ${componets[1].length}`);
-                }
-
-                let index = +currentIndex.index;
-                let functionalUnitType = componets[0];
-                let functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
-                let predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
-
-                // Check if the recived functional unit type is the same as the one in the code
-                if (functionalUnitType !== currentIndex.functionalUnitType) {
-                    throw new TokenError(componets[1][0].pos, `Invalid functional unit type ${FunctionalUnitTypeNames[functionalUnitType]} for instruction ${index}(expected ${FunctionalUnitTypeNames[currentIndex.functionalUnitType]})`);
-                }
-
-
-                let operation = new VLIWOperation(null, code.instructions[index], functionalUnitType, functionalUnitIndex);
-                operation.setPred(predicate);
-
-                if (currentIndex.isJump) {
-                    // Check if we received the right amount of operands
-                    if (componets[1].length !== 5) {
-                        throw new TokenError(componets[1][componets[1].length - 1].pos, `Expected 5 operands(Jump operation), received ${componets[1].length}`);
-                    }
-                    let destiny = +componets[1][2].text;
-                    let predTrue = +componets[1][3].text;
-                    let predFalse = +componets[1][4].text;
-
-                    operation.setOperand(2, destiny, '');
-                    operation.setPredTrue(predTrue);
-                    operation.setPredFalse(predFalse);
-                }
-                return operation;
-            }
-        );
-
-        const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
-        const programParser = seq(opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))), list_sc(lineParser, tok(Tokens.NewLine)), opt_sc(tok(Tokens.NewLine)));
-
-        // Lets parse the input
-        let result = expectSingleResult(expectEOF(programParser.parse(tokenizer.parse(input))));
-
-        //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
-        let instructions: LargeInstruction[] = new Array<LargeInstruction>(result[1].length);
-        let instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
-
-        for (let i = 0; i < instructionsLines.length; i++) {
-            instructions[i] = new LargeInstruction();
-
-            let operationsAmount = +instructionsLines[i][0].text; // This is also a retrocompatibility thing, we don't really use it
-
-            // Iterate over the operations
-            instructionsLines[i][1].forEach(operation => {
-                instructions[i].addOperation(operation);
-            });
-        }
-
-        return instructions;
+export function Parse(input: string, code: Code): LargeInstruction[] {
+  // This parses depends on the code, so we moved it here
+  const indexParser = apply(
+    tok(Tokens.Number),
+    (num: Token<Tokens.Number>): IndexParsed => {
+      const index = +num.text;
+      // Check if index is not out of bounds
+      if (index >= code.instructions.length) {
+        throw new TokenError(num.pos, `Invalid index ${index}`);
+      }
+      return {
+        index: index,
+        isJump: code.instructions[index].isJumpInstruction(),
+        functionalUnitType: code.instructions[index].getFunctionalUnitType(),
+      };
     }
+  );
 
-    public static ExportAsString(_instructionNumber: number, _instructions: LargeInstruction[]): string {
+  // This other parsers depends on the previous one, so we need to declare it here also
 
-        let outputString: string;
-        outputString += _instructionNumber;
+  let currentIndex: IndexParsed = null; // This is a ugly hack, but unfortunately combine consumes the index that we need in operationParser
+  const operationCombiner = combine(indexParser, (indexParsed: IndexParsed) => {
+    currentIndex = indexParsed;
+    const numOfElements = indexParsed.isJump ? 5 : 2;
+    return seq(
+      functionalUnitTypeParser,
+      rep_n(tok(Tokens.Number), numOfElements)
+    );
+  });
 
-        for (let i = 0; i < _instructionNumber; i++) {
-            let operationAmount = _instructions[i].getVLIWOperationsNumber();
-            outputString += operationAmount;
+  const operationParser = apply(
+    operationCombiner,
+    (componets: [FunctionalUnitType, Token<Tokens>[]]) => {
+      // Check if we received the right amount of operands
+      if (componets[1].length < 2) {
+        throw new TokenError(
+          componets[1][0].pos,
+          `Expected at least 2 operands, received ${componets[1].length}`
+        );
+      }
 
-            for (let j = 0; j < operationAmount; j++) {
+      const index = +currentIndex.index;
+      const functionalUnitType = componets[0];
+      const functionalUnitIndex = +componets[1][0].text; //TODO: Check if this is out of bounds
+      const predicate = +componets[1][1].text; //TODO: Check if this is out of bounds
 
-                let operation = _instructions[i].getOperation(j);
-                outputString += '\t';
-                outputString += operation.id;
-                outputString += ' ';
-                outputString += operation.getFunctionalUnitType();
-                outputString += ' ';
-                outputString += operation.getFunctionalUnitType();
-                outputString += ' ';
-                outputString += operation.getPred();
+      // Check if the recived functional unit type is the same as the one in the code
+      if (functionalUnitType !== currentIndex.functionalUnitType) {
+        throw new TokenError(
+          componets[1][0].pos,
+          `Invalid functional unit type ${
+            FunctionalUnitTypeNames[functionalUnitType]
+          } for instruction ${index}(expected ${
+            FunctionalUnitTypeNames[currentIndex.functionalUnitType]
+          })`
+        );
+      }
 
-                if (operation.isJumpInstruction()) {
-                    outputString += ' ';
-                    outputString += operation.getOperand(2);
-                    outputString += ' ';
-                    outputString += operation.getPredTrue();
-                    outputString += ' ';
-                    outputString += operation.getPredFalse();
-                }
-            }
-            outputString += '\n';
+      const operation = new VLIWOperation(
+        null,
+        code.instructions[index],
+        functionalUnitType,
+        functionalUnitIndex
+      );
+      operation.setPred(predicate);
+
+      if (currentIndex.isJump) {
+        // Check if we received the right amount of operands
+        if (componets[1].length !== 5) {
+          throw new TokenError(
+            componets[1][componets[1].length - 1].pos,
+            `Expected 5 operands(Jump operation), received ${componets[1].length}`
+          );
         }
-        return outputString;
+        const destiny = +componets[1][2].text;
+        const predTrue = +componets[1][3].text;
+        const predFalse = +componets[1][4].text;
+
+        operation.setOperand(2, destiny, "");
+        operation.setPredTrue(predTrue);
+        operation.setPredFalse(predFalse);
+      }
+      return operation;
     }
+  );
+
+  const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
+  const programParser = seq(
+    opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
+    list_sc(lineParser, tok(Tokens.NewLine)),
+    opt_sc(tok(Tokens.NewLine))
+  );
+
+  // Lets parse the input
+  const result = expectSingleResult(
+    expectEOF(programParser.parse(tokenizer.parse(input)))
+  );
+
+  //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
+  const instructions: LargeInstruction[] = new Array<LargeInstruction>(
+    result[1].length
+  );
+  const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
+
+  for (let i = 0; i < instructionsLines.length; i++) {
+    instructions[i] = new LargeInstruction();
+
+    // Iterate over the operations
+    for (const operation of instructionsLines[i][1]) {
+      instructions[i].addOperation(operation);
+    }
+  }
+
+  return instructions;
+}
+
+export function ExportAsString(
+  _instructionNumber: number,
+  _instructions: LargeInstruction[]
+): string {
+  let outputString: string;
+  outputString += _instructionNumber;
+
+  for (let i = 0; i < _instructionNumber; i++) {
+    const operationAmount = _instructions[i].getVLIWOperationsNumber();
+    outputString += operationAmount;
+
+    for (let j = 0; j < operationAmount; j++) {
+      const operation = _instructions[i].getOperation(j);
+      outputString += "\t";
+      outputString += operation.id;
+      outputString += " ";
+      outputString += operation.getFunctionalUnitType();
+      outputString += " ";
+      outputString += operation.getFunctionalUnitType();
+      outputString += " ";
+      outputString += operation.getPred();
+
+      if (operation.isJumpInstruction()) {
+        outputString += " ";
+        outputString += operation.getOperand(2);
+        outputString += " ";
+        outputString += operation.getPredTrue();
+        outputString += " ";
+        outputString += operation.getPredFalse();
+      }
+    }
+    outputString += "\n";
+  }
+  return outputString;
 }

--- a/src/core/VLIW/VLIWParser.ts
+++ b/src/core/VLIW/VLIWParser.ts
@@ -1,26 +1,26 @@
+import type { Code } from "@/core/Common/Code";
 import {
-  apply,
-  buildLexer,
-  expectEOF,
-  expectSingleResult,
-  rep_sc,
-  rep_n,
-  seq,
-  tok,
-  combine,
-  opt_sc,
   type Token,
   TokenError,
+  apply,
+  buildLexer,
+  combine,
+  expectEOF,
+  expectSingleResult,
   list_sc,
+  opt_sc,
+  rep_n,
+  rep_sc,
+  seq,
+  tok,
 } from "typescript-parsec";
-import { LargeInstruction } from "./LargeInstructions";
-import type { Code } from "../Common/Code";
-import { VLIWOperation } from "./VLIWOperation";
 import {
+  FUNCTIONALUNITTYPESQUANTITY,
   type FunctionalUnitType,
   FunctionalUnitTypeNames,
-  FUNCTIONALUNITTYPESQUANTITY,
 } from "../Common/FunctionalUnit";
+import { LargeInstruction } from "./LargeInstructions";
+import { VLIWOperation } from "./VLIWOperation";
 
 enum Tokens {
   Number = 0,
@@ -46,7 +46,7 @@ const functionalUnitTypeParser = apply(
       throw new TokenError(num.pos, `Invalid functional unit type ${type}`);
     }
     return type;
-  }
+  },
 );
 
 interface IndexParsed {
@@ -70,7 +70,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
         isJump: code.instructions[index].isJumpInstruction(),
         functionalUnitType: code.instructions[index].getFunctionalUnitType(),
       };
-    }
+    },
   );
 
   // This other parsers depends on the previous one, so we need to declare it here also
@@ -81,7 +81,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
     const numOfElements = indexParsed.isJump ? 5 : 2;
     return seq(
       functionalUnitTypeParser,
-      rep_n(tok(Tokens.Number), numOfElements)
+      rep_n(tok(Tokens.Number), numOfElements),
     );
   });
 
@@ -92,7 +92,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
       if (componets[1].length < 2) {
         throw new TokenError(
           componets[1][0].pos,
-          `Expected at least 2 operands, received ${componets[1].length}`
+          `Expected at least 2 operands, received ${componets[1].length}`,
         );
       }
 
@@ -109,7 +109,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
             FunctionalUnitTypeNames[functionalUnitType]
           } for instruction ${index}(expected ${
             FunctionalUnitTypeNames[currentIndex.functionalUnitType]
-          })`
+          })`,
         );
       }
 
@@ -117,7 +117,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
         null,
         code.instructions[index],
         functionalUnitType,
-        functionalUnitIndex
+        functionalUnitIndex,
       );
       operation.setPred(predicate);
 
@@ -126,7 +126,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
         if (componets[1].length !== 5) {
           throw new TokenError(
             componets[1][componets[1].length - 1].pos,
-            `Expected 5 operands(Jump operation), received ${componets[1].length}`
+            `Expected 5 operands(Jump operation), received ${componets[1].length}`,
           );
         }
         const destiny = +componets[1][2].text;
@@ -138,24 +138,24 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
         operation.setPredFalse(predFalse);
       }
       return operation;
-    }
+    },
   );
 
   const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
   const programParser = seq(
     opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))),
     list_sc(lineParser, tok(Tokens.NewLine)),
-    opt_sc(tok(Tokens.NewLine))
+    opt_sc(tok(Tokens.NewLine)),
   );
 
   // Lets parse the input
   const result = expectSingleResult(
-    expectEOF(programParser.parse(tokenizer.parse(input)))
+    expectEOF(programParser.parse(tokenizer.parse(input))),
   );
 
   //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
   const instructions: LargeInstruction[] = new Array<LargeInstruction>(
-    result[1].length
+    result[1].length,
   );
   const instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
 
@@ -173,7 +173,7 @@ export function Parse(input: string, code: Code): LargeInstruction[] {
 
 export function ExportAsString(
   _instructionNumber: number,
-  _instructions: LargeInstruction[]
+  _instructions: LargeInstruction[],
 ): string {
   let outputString: string;
   outputString += _instructionNumber;

--- a/src/core/VLIW/VLIWParser.ts
+++ b/src/core/VLIW/VLIWParser.ts
@@ -104,14 +104,14 @@ export class VLIWParser {
         );
 
         const lineParser = seq(tok(Tokens.Number), rep_sc(operationParser));
-        const programParser = seq(tok(Tokens.Number), tok(Tokens.NewLine), list_sc(lineParser, tok(Tokens.NewLine)), opt_sc(tok(Tokens.NewLine)));
+        const programParser = seq(opt_sc(seq(tok(Tokens.Number), tok(Tokens.NewLine))), list_sc(lineParser, tok(Tokens.NewLine)), opt_sc(tok(Tokens.NewLine)));
 
         // Lets parse the input
         let result = expectSingleResult(expectEOF(programParser.parse(tokenizer.parse(input))));
 
-        let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
-        let instructions: LargeInstruction[] = new Array<LargeInstruction>(result[2].length);
-        let instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[2];
+        //let linesNumber: number = +result[0].text; // Let's extract the amount of lines, this is a retrocompatibility thing, we don't really use it
+        let instructions: LargeInstruction[] = new Array<LargeInstruction>(result[1].length);
+        let instructionsLines: [Token<Tokens>, VLIWOperation[]][] = result[1];
 
         for (let i = 0; i < instructionsLines.length; i++) {
             instructions[i] = new LargeInstruction();

--- a/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
+++ b/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
@@ -1,59 +1,60 @@
-import * as React from 'react';
-import FileReaderInput from '../../Common/FileReaderInput';
-import { Modal, Button } from 'react-bootstrap';
-import { withTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
-import { toggleLoadModal } from '../../../actions/modals';
-import { bindActionCreators } from 'redux';
+import { toggleLoadModal } from "@/interface/actions/modals";
+import FileReaderInput from "@/interface/components/Common/FileReaderInput";
+import { Button, Modal } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
 
-import SuperescalarIntegration from '../../../../integration/superescalar-integration';
-import { Code } from '../../../../core/Common/Code';
+import { Code } from "@/core/Common/Code";
+import SuperescalarIntegration from "@/integration/superescalar-integration";
 
-export class LoadModalComponent extends React.Component<any, any> {
+export const LoadModalComponent = ({ props, state }) => {
+  const [t] = useTranslation();
 
-    constructor(public props: any, public state: any) {
-        super(props);
-        this.close = this.close.bind(this);
-        this.loadCode = this.loadCode.bind(this);
+  const close = () => {
+    props.actions.toggleLoadModal(false);
+  };
+
+  const handleInputFileChange = (_, results) => {
+    for (const result of results) {
+      const [e, file] = result;
+      const a = document.getElementById("codeInput") as HTMLInputElement;
+      a.value = e.target.result;
     }
+  };
 
-    close() {
-        this.props.actions.toggleLoadModal(false);
-    };
-
-    handleInputFileChange = (e, results) => {
-        results.forEach(result => {
-            const [e, file] = result;
-            let a = document.getElementById('codeInput') as HTMLInputElement;
-            a.value = e.target.result;
-        });
+  const loadCode = () => {
+    try {
+      const code = new Code();
+      code.load(
+        (document.getElementById("codeInput") as HTMLInputElement).value,
+      );
+      state = { error: "" };
+      SuperescalarIntegration.loadCode(code);
+      close();
+    } catch (error) {
+      // Check if error has the property position. Checking instance of TokenError not working
+      state = {
+        error: error.pos
+          ? `[${error.pos?.rowBegin}:${error.pos?.columnBegin}]: ${error.errorMessage}`
+          : error.message,
+      };
     }
+  };
 
-    loadCode() {
-        try {
-            let code = new Code();
-            code.load((document.getElementById('codeInput') as HTMLInputElement).value);
-            this.setState({error: ''})
-            SuperescalarIntegration.loadCode(code);
-            this.close();
-        } catch (error) {
-            // Check if error has the property position. Checking instance of TokenError not working
-            if (error.pos) {
-                this.setState({error: '[' + error.pos?.rowBegin + ':' + error.pos?.columnBegin + ']: ' + error.errorMessage});
-            } else {
-                this.setState({error: error.message});
-            }
-        }
-    }
-
-    render() {
-        return (
-        <Modal className="smd-load_modal" show={this.props.isLoadModalOpen} onHide={this.close}>
-            <Modal.Header closeButton>
-                <Modal.Title>{this.props.t('loadModal.title')}</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <textarea id='codeInput' defaultValue={`   ADDI	R2 R0 #50
+  return (
+    <Modal
+      className="smd-load_modal"
+      show={props.isLoadModalOpen}
+      onHide={close}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>{t("loadModal.title")}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <textarea
+          id="codeInput"
+          defaultValue={`   ADDI	R2 R0 #50
    ADDI	R3 R0 #70
    ADDI	R4 R0 #40
    LF	F0 (R4)
@@ -73,36 +74,44 @@ LOOP:
 // Ending Code
    SF	F2 (R3)
    ADDF	F2 F1 F0
-   SF	F2 1(R3)`}>
-                </textarea>
-                <div className="smd-load_modal-errors">
-                    {this.state.error && <div className="smd-forms_error">{this.state.error}</div>}
-                </div>
-            </Modal.Body>
+   SF	F2 1(R3)`}
+        />
+        <div className="smd-load_modal-errors">
+          {state.error && <div className="smd-forms_error">{state.error}</div>}
+        </div>
+      </Modal.Body>
 
-            <Modal.Footer className="smd-load_modal-footer">
-                <div className="smd-load_modal-file_input">
-                    <FileReaderInput as='text' onChange={this.handleInputFileChange} accept='.pla'>
-                        <Button className='btn btn-primary'>{this.props.t('commonButtons.loadFromFile')}</Button>
-                    </FileReaderInput>
-                </div>
-                <div className="smd-load_modal-actions">
-                    <Button onClick={this.close}>{this.props.t('commonButtons.close')}</Button>
-                    <Button className='btn btn-primary' onClick={this.loadCode}>{this.props.t('loadModal.load')}</Button>
-                </div>
-            </Modal.Footer>
-        </Modal>);
-    }
-}
+      <Modal.Footer className="smd-load_modal-footer">
+        <div className="smd-load_modal-file_input">
+          <FileReaderInput
+            as="text"
+            onChange={handleInputFileChange}
+            accept=".pla"
+          >
+            <Button className="btn btn-primary">
+              {t("commonButtons.loadFromFile")}
+            </Button>
+          </FileReaderInput>
+        </div>
+        <div className="smd-load_modal-actions">
+          <Button onClick={close}>{t("commonButtons.close")}</Button>
+          <Button className="btn btn-primary" onClick={loadCode}>
+            {t("loadModal.load")}
+          </Button>
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+};
 
-const mapStateToProps = state => {
-    return {
-        isLoadModalOpen: state.Ui.isLoadModalOpen,
-    }
-}
+const mapStateToProps = (state) => {
+  return {
+    isLoadModalOpen: state.Ui.isLoadModalOpen,
+  };
+};
 
 function mapDispatchToProps(dispatch) {
-    return { actions: bindActionCreators({toggleLoadModal}, dispatch)};
+  return { actions: bindActionCreators({ toggleLoadModal }, dispatch) };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(LoadModalComponent));
+export default connect(mapStateToProps, mapDispatchToProps)(LoadModalComponent);

--- a/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
+++ b/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
@@ -8,11 +8,29 @@ import { bindActionCreators } from "redux";
 import { Code } from "@/core/Common/Code";
 import SuperescalarIntegration from "@/integration/superescalar-integration";
 
-export const LoadModalComponent = ({ props, state }) => {
+const mapStateToProps = (state) => {
+  return {
+    isLoadModalOpen: state.Ui.isLoadModalOpen,
+    error: "",
+  };
+};
+
+function mapDispatchToProps(dispatch) {
+  return { actions: bindActionCreators({ toggleLoadModal }, dispatch) };
+}
+
+export type LoadModalComponentProps = ReturnType<typeof mapStateToProps> &
+  ReturnType<typeof mapDispatchToProps>;
+
+export const LoadModalComponent = ({
+  isLoadModalOpen,
+  error: modalError,
+  actions,
+}: LoadModalComponentProps) => {
   const [t] = useTranslation();
 
   const close = () => {
-    props.actions.toggleLoadModal(false);
+    actions.toggleLoadModal(false);
   };
 
   const handleInputFileChange = (_, results) => {
@@ -29,25 +47,19 @@ export const LoadModalComponent = ({ props, state }) => {
       code.load(
         (document.getElementById("codeInput") as HTMLInputElement).value,
       );
-      state = { error: "" };
+      modalError = "";
       SuperescalarIntegration.loadCode(code);
       close();
     } catch (error) {
       // Check if error has the property position. Checking instance of TokenError not working
-      state = {
-        error: error.pos
-          ? `[${error.pos?.rowBegin}:${error.pos?.columnBegin}]: ${error.errorMessage}`
-          : error.message,
-      };
+      modalError = error.pos
+        ? `[${error.pos?.rowBegin}:${error.pos?.columnBegin}]: ${error.errorMessage}`
+        : error.message;
     }
   };
 
   return (
-    <Modal
-      className="smd-load_modal"
-      show={props.isLoadModalOpen}
-      onHide={close}
-    >
+    <Modal className="smd-load_modal" show={isLoadModalOpen} onHide={close}>
       <Modal.Header closeButton>
         <Modal.Title>{t("loadModal.title")}</Modal.Title>
       </Modal.Header>
@@ -77,7 +89,7 @@ LOOP:
    SF	F2 1(R3)`}
         />
         <div className="smd-load_modal-errors">
-          {state.error && <div className="smd-forms_error">{state.error}</div>}
+          {modalError && <div className="smd-forms_error">{modalError}</div>}
         </div>
       </Modal.Body>
 
@@ -103,15 +115,5 @@ LOOP:
     </Modal>
   );
 };
-
-const mapStateToProps = (state) => {
-  return {
-    isLoadModalOpen: state.Ui.isLoadModalOpen,
-  };
-};
-
-function mapDispatchToProps(dispatch) {
-  return { actions: bindActionCreators({ toggleLoadModal }, dispatch) };
-}
 
 export default connect(mapStateToProps, mapDispatchToProps)(LoadModalComponent);

--- a/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
+++ b/src/interface/components/Superescalar/modal/LoadModalComponent.tsx
@@ -53,8 +53,7 @@ export class LoadModalComponent extends React.Component<any, any> {
                 <Modal.Title>{this.props.t('loadModal.title')}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                <textarea id='codeInput' defaultValue={`18
-   ADDI	R2 R0 #50
+                <textarea id='codeInput' defaultValue={`   ADDI	R2 R0 #50
    ADDI	R3 R0 #70
    ADDI	R4 R0 #40
    LF	F0 (R4)

--- a/src/interface/components/VLIW/modal/VLIWLoadModalComponent.tsx
+++ b/src/interface/components/VLIW/modal/VLIWLoadModalComponent.tsx
@@ -77,8 +77,7 @@ export class VLIWLoadModalComponent extends React.Component<any, any> {
                 <Modal.Title>{this.props.t('loadModal.title')}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                <textarea id='superescalarCodeInput' defaultValue={`11
-	ADDI	R2 R0 #50
+                <textarea id='superescalarCodeInput' defaultValue={`	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
 	LF	F0 (R4)
@@ -94,8 +93,7 @@ LOOP:
                 <div className="smd-load_modal-errors">
                     {this.state.superescalarCodeError && <div className="smd-forms_error">{this.state.superescalarCodeError}</div>}
                 </div>
-                <textarea id='vliwCodeInput' defaultValue={`15
-    2	0 0 0 0	2 0 1 0
+                <textarea id='vliwCodeInput' defaultValue={`    2	0 0 0 0	2 0 1 0
     3	1 0 0 0	4 0 1 0	3 4 0 0
     1	5 4 0 0
     0

--- a/src/test/unit/core/Common/Code.spec.ts
+++ b/src/test/unit/core/Common/Code.spec.ts
@@ -1,19 +1,17 @@
-import { expect, beforeEach, test } from 'vitest'
-import { Code } from '../../../../core/Common/Code';
+import { beforeEach, expect, test } from "vitest";
+import { Code } from "../../../../core/Common/Code";
 
 const input = `2
 ADDI	R2 R0 #50
 ADD     R3 R0 R2
 `;
 
-const inputWithComments =
-	`// This is a comment
+const inputWithComments = `// This is a comment
 // And just another comment
 2
 ADDI	R2 R0 #50
 ADD     R3 R0 R2
 `;
-
 
 const input2 = `1
 LF F0 (R4)
@@ -28,137 +26,165 @@ BNE	R2 R5 LOOP
 // =============================
 // PARSING ERRORS
 // =============================
-test('Lines are being parsed properly', t => {
-	let code: Code = new Code();
-	code.load(input);
-	expect(2).toBe(code.lines);
-	code = new Code();
-	code.load(input2);
-	expect(1).toBe(code.lines);
+test("Lines are being parsed properly", (t) => {
+  let code: Code = new Code();
+  code.load(input);
+  expect(2).toBe(code.lines);
+  code = new Code();
+  code.load(input2);
+  expect(1).toBe(code.lines);
 });
 
-test('Lines counter is ignored', t => {
-	const input = `1
+test("Lines counter is ignored", (t) => {
+  const input = `1
         LF F1 (R2)
         LOOP:
         ADDF F1 F1 F0
         BNE	R2 R5 LOOP
         `;
-	let code: Code = new Code();
-	code.load(input);
-	expect(3).toBe(code.lines);
+  const code: Code = new Code();
+  code.load(input);
+  expect(3).toBe(code.lines);
 });
 
-test('Lines counter can be ommited', t => {
-	const input = `LF F1 (R2)
+test("Lines counter can be ommited", (t) => {
+  const input = `LF F1 (R2)
         LOOP:
         ADDF F1 F1 F0
         BNE	R2 R5 LOOP
         `;
-	let code: Code = new Code();
-	code.load(input);
-	expect(3).toBe(code.lines);
+  const code: Code = new Code();
+  code.load(input);
+  expect(3).toBe(code.lines);
 });
 
-test('Commentaries on top should not affect the parsing', t => {
-	let code: Code = new Code();
-	code.load(inputWithComments);
-	expect(2).toBe(code.lines);
+test("Commentaries on top should not affect the parsing", (t) => {
+  const code: Code = new Code();
+  code.load(inputWithComments);
+  expect(2).toBe(code.lines);
 });
 
-test('Parsing operand errors are being thrown', t => {
-	const input = `3
+test("Parsing operand errors are being thrown", (t) => {
+  const input = `3
         LF F1 (R2)
         LOOP:
         ADDF F1 F1 H0
         BNE	R2 R5 LOOP
         `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).toThrowError('{"index":43,"rowBegin":4,"columnBegin":9,"rowEnd":4,"columnEnd":13}: Invalid instruction format for ADDF. Expected TwoFloatingRegisters format, got Jump format or similar');
+  const code: Code = new Code();
+  expect(() => code.load(input)).toThrowError(
+    '{"index":43,"rowBegin":4,"columnBegin":9,"rowEnd":4,"columnEnd":13}: Invalid instruction format for ADDF. Expected TwoFloatingRegisters format, got Jump format or similar',
+  );
 });
 
-test('Parsing addresses errors are being throw', t => {
-	const input = `3
+test("Parsing addresses errors are being throw", (t) => {
+  const input = `3
     LF F1 (R-2)
     LOOP:
     ADDF F1 F1 F0
     BNE	R2 R5 LOOP
     `;
 
-	let code = new Code();
-	expect(() => code.load(input)).toThrowError('{"index":6,"rowBegin":2,"columnBegin":5,"rowEnd":2,"columnEnd":7}: Invalid instruction format for LF. Expected FloatingLoadStore format, got Noop format or similar');
+  const code = new Code();
+  expect(() => code.load(input)).toThrowError(
+    '{"index":6,"rowBegin":2,"columnBegin":5,"rowEnd":2,"columnEnd":7}: Invalid instruction format for LF. Expected FloatingLoadStore format, got Noop format or similar',
+  );
 });
 
-test('Parsing opcodes errors are being thrown', t => {
-	const input = `3
+test("Parsing opcodes errors are being thrown", (t) => {
+  const input = `3
     LF F1 (R2)
     LOOP:
     ADF F1 F1 F0
     BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).toThrowError('{"index":31,"rowBegin":4,"columnBegin":5,"rowEnd":4,"columnEnd":8}: Unknown opcode ADF');
+  const code: Code = new Code();
+  expect(() => code.load(input)).toThrowError(
+    '{"index":31,"rowBegin":4,"columnBegin":5,"rowEnd":4,"columnEnd":8}: Unknown opcode ADF',
+  );
 });
 
-test('Repeated labels errors are being thrown', t => {
-	const input = `3
+test("Repeated labels errors are being thrown", (t) => {
+  const input = `3
     LF F1 (R2)
     LOOP:
     ADDF F1 F1 F0
     LOOP:
     BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).toThrowError('Error at instruction 2, label LOOP already exists');
+  const code: Code = new Code();
+  expect(() => code.load(input)).toThrowError(
+    "Error at instruction 2, label LOOP already exists",
+  );
 });
 
-test('Parsing strange inmediates throws errors', t => {
-	const input = `1
+test("Parsing strange inmediates throws errors", (t) => {
+  const input = `1
 	ADDI R0 R0 #0x0`;
-	const inpu2 = `1
+  const inpu2 = `1
 	ADDI R0 R0 #0.0`;
-	const inpu3 = `1
+  const inpu3 = `1
 	ADDI R0 R0 #(0)`;
-	const inpu4 = `1
+  const inpu4 = `1
 	ADDI R0 R0 #R0`;
-	let code: Code = new Code();
+  const code: Code = new Code();
 
-	expect(() => code.load(input)).toThrowError('{"index":16,"rowBegin":2,"columnBegin":15,"rowEnd":2,"columnEnd":17}: Unknown opcode x0');
-	expect(() => code.load(inpu2)).toThrowError('{"index":16,"rowBegin":2,"columnBegin":15,"rowEnd":2,"columnEnd":15}: Unable to tokenize the rest of the input: .0');
-	expect(() => code.load(inpu3)).toThrowError('{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":13}: Unable to tokenize the rest of the input: #(0)');
-	expect(() => code.load(inpu4)).toThrowError('{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":13}: Unable to tokenize the rest of the input: #R0');
+  expect(() => code.load(input)).toThrowError(
+    '{"index":16,"rowBegin":2,"columnBegin":15,"rowEnd":2,"columnEnd":17}: Unknown opcode x0',
+  );
+  expect(() => code.load(inpu2)).toThrowError(
+    '{"index":16,"rowBegin":2,"columnBegin":15,"rowEnd":2,"columnEnd":15}: Unable to tokenize the rest of the input: .0',
+  );
+  expect(() => code.load(inpu3)).toThrowError(
+    '{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":13}: Unable to tokenize the rest of the input: #(0)',
+  );
+  expect(() => code.load(inpu4)).toThrowError(
+    '{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":13}: Unable to tokenize the rest of the input: #R0',
+  );
 });
 
-test('Parsing strange registers throws errors', t => {
-	const input = `1
+test("Parsing strange registers throws errors", (t) => {
+  const input = `1
 	ADDI R0.0 R0 #0`;
-	const inpu2 = `1
+  const inpu2 = `1
 	ADDI R0x0 R0 #0`;
-	const inpu3 = `1
+  const inpu3 = `1
 	ADDI R(0) R0 #0`;
-	let code: Code = new Code();
+  const code: Code = new Code();
 
-	expect(() => code.load(input)).toThrowError('{"index":10,"rowBegin":2,"columnBegin":9,"rowEnd":2,"columnEnd":9}: Unable to tokenize the rest of the input: .0 R0 #0');
-	expect(() => code.load(inpu2)).toThrowError('{"index":3,"rowBegin":2,"columnBegin":2,"rowEnd":2,"columnEnd":6}: Invalid instruction format for ADDI. Expected GeneralRegisterAndInmediate format, got Noop format or similar');
-	expect(() => code.load(inpu3)).toThrowError('{"index":3,"rowBegin":2,"columnBegin":2,"rowEnd":2,"columnEnd":6}: Invalid instruction format for ADDI. Expected GeneralRegisterAndInmediate format, got Noop format or similar');
+  expect(() => code.load(input)).toThrowError(
+    '{"index":10,"rowBegin":2,"columnBegin":9,"rowEnd":2,"columnEnd":9}: Unable to tokenize the rest of the input: .0 R0 #0',
+  );
+  expect(() => code.load(inpu2)).toThrowError(
+    '{"index":3,"rowBegin":2,"columnBegin":2,"rowEnd":2,"columnEnd":6}: Invalid instruction format for ADDI. Expected GeneralRegisterAndInmediate format, got Noop format or similar',
+  );
+  expect(() => code.load(inpu3)).toThrowError(
+    '{"index":3,"rowBegin":2,"columnBegin":2,"rowEnd":2,"columnEnd":6}: Invalid instruction format for ADDI. Expected GeneralRegisterAndInmediate format, got Noop format or similar',
+  );
 });
 
-test('Parser check bounds', t => {
-	const input = `1
+test("Parser check bounds", (t) => {
+  const input = `1
 	ADDI R128 R0 #0`;
-	const inpu2 = `1
+  const inpu2 = `1
 	ADDF F128 F0 F0`;
-	const inpu3 = `1
+  const inpu3 = `1
 	SF R0 1025(F0)`;
-	let code: Code = new Code();
+  const code: Code = new Code();
 
-	expect(() => code.load(input)).toThrowError('{"index":8,"rowBegin":2,"columnBegin":7,"rowEnd":2,"columnEnd":11}: Destiny register number out of bounds');
-	expect(() => code.load(inpu2)).toThrowError('{"index":8,"rowBegin":2,"columnBegin":7,"rowEnd":2,"columnEnd":11}: Destiny register number out of bounds');
-	expect(() => code.load(inpu3)).toThrowError('{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":15}: Address register cannot be FP register');
+  expect(() => code.load(input)).toThrowError(
+    '{"index":8,"rowBegin":2,"columnBegin":7,"rowEnd":2,"columnEnd":11}: Destiny register number out of bounds',
+  );
+  expect(() => code.load(inpu2)).toThrowError(
+    '{"index":8,"rowBegin":2,"columnBegin":7,"rowEnd":2,"columnEnd":11}: Destiny register number out of bounds',
+  );
+  expect(() => code.load(inpu3)).toThrowError(
+    '{"index":14,"rowBegin":2,"columnBegin":13,"rowEnd":2,"columnEnd":15}: Address register cannot be FP register',
+  );
 });
 
-test('Example code 1 does not throws errors', t => {
-	const input = `11
+test("Example code 1 does not throws errors", (t) => {
+  const input = `11
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -172,12 +198,12 @@ LOOP:
 	ADDI	R3 R3 #1
 	BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 2 does not throws errors', t => {
-	const input = `14
+test("Example code 2 does not throws errors", (t) => {
+  const input = `14
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -194,12 +220,12 @@ LOOP:
 	ADDI	R3 R3 #2
 	BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 3 does not throws errors', t => {
-	const input = `20
+test("Example code 3 does not throws errors", (t) => {
+  const input = `20
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -222,12 +248,12 @@ LOOP:
 	ADDI	R3 R3 #4
 	BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 4 does not throws errors', t => {
-	const input = `32
+test("Example code 4 does not throws errors", (t) => {
+  const input = `32
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -262,12 +288,12 @@ LOOP:
 	ADDI	R3 R3 #8
 	BNE	R2 R5 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 5 does not throws errors', t => {
-	const input = `18
+test("Example code 5 does not throws errors", (t) => {
+  const input = `18
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -289,12 +315,12 @@ LOOP2:
 	ADDI	R3 R3 #1
 	BNE	R3 R5 LOOP2
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 6 does not throws errors', t => {
-	const input = `8
+test("Example code 6 does not throws errors", (t) => {
+  const input = `8
 	ADDI	R1 R0 #1
 	ADDI	R2 R0 #2
 	ADDI	R3 R0 #0
@@ -305,12 +331,12 @@ LOOP:
 	ADDI	R3 R3 #1
 	BNE	R3 R4 LOOP
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 7 does not throws errors', t => {
-	const input = `18
+test("Example code 7 does not throws errors", (t) => {
+  const input = `18
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -333,12 +359,12 @@ LOOP:
 	ADDF	F2 F1 F0
 	SF	F2 1(R3)
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 8 does not throws errors', t => {
-	const input = `27
+test("Example code 8 does not throws errors", (t) => {
+  const input = `27
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -370,12 +396,12 @@ LOOP:
 	SF	F2 2(R3)
 	SF	F4 3(R3)
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 9 does not throws errors', t => {
-	const input = `13
+test("Example code 9 does not throws errors", (t) => {
+  const input = `13
 // CODIGO:
 	ADDI	R10, R0, #10
 	ADDI	R1, R0, #0
@@ -394,12 +420,12 @@ B:
 FIN:
 	SF		F3, 2(R10)
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 10 does not throws errors', t => {
-	const input = `7
+test("Example code 10 does not throws errors", (t) => {
+  const input = `7
 ADDI R2 R0 #3
 BGT R0 R2 ET1
 ADDI R3 R0 #2
@@ -410,12 +436,12 @@ SUB R5 R2 R3
 ET2:
 SUB R6 R2 R3
     `;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });
 
-test('Example code 11 does not throws errors', t => {
-	const input = `26
+test("Example code 11 does not throws errors", (t) => {
+  const input = `26
 	ADDI	R33 R0 #-1
 	ADDI	R34 R0 #400
 	ADDI	R1 R0 #-1
@@ -460,6 +486,6 @@ FIN:
 	// Operación nula: Es necesaria porque el simulador exige que todas las etiquetas
 	// vayan asociadas a una operación.
 	ADDI	R0 R0 #0`;
-	let code: Code = new Code();
-	expect(() => code.load(input)).not.toThrowError();
+  const code: Code = new Code();
+  expect(() => code.load(input)).not.toThrowError();
 });

--- a/src/test/unit/core/Common/Code.spec.ts
+++ b/src/test/unit/core/Common/Code.spec.ts
@@ -49,6 +49,17 @@ test('Lines counter is ignored', t => {
 	expect(3).toBe(code.lines);
 });
 
+test('Lines counter can be ommited', t => {
+	const input = `LF F1 (R2)
+        LOOP:
+        ADDF F1 F1 F0
+        BNE	R2 R5 LOOP
+        `;
+	let code: Code = new Code();
+	code.load(input);
+	expect(3).toBe(code.lines);
+});
+
 test('Commentaries on top should not affect the parsing', t => {
 	let code: Code = new Code();
 	code.load(inputWithComments);

--- a/src/test/unit/core/VLIW/VLIWParser.spec.ts
+++ b/src/test/unit/core/VLIW/VLIWParser.spec.ts
@@ -51,7 +51,45 @@ LOOP:
 
     const error = `Bad instruction number parsed, expected 15, got ${context.code.getLargeInstructionNumber()}`;
 
-    expect(context.code.getLargeInstructionNumber()).toBe( 15);
+    expect(context.code.getLargeInstructionNumber()).toBe(15);
+});
+
+test('Loop.pla without lines number is loaded properly', t => {
+
+    const inputVLIW =
+        `    2	0 0 0 0	2 0 1 0
+    3	1 0 0 0	4 0 1 0	3 4 0 0
+    1	5 4 0 0
+    0
+    0
+    0
+    1	6 2 0 0
+    1	8 0 0 0
+    0
+    0
+    1	7 4 1 0
+    0
+    0
+    1	10 5 0 0 2 1 2
+    1	9 0 1 0`;
+
+    const inputSuperescalar = `ADDI	R2 R0 #50
+	ADDI	R3 R0 #70
+	ADDI	R4 R0 #40
+	LF	F0 (R4)
+	ADDI	R5 R2 #16
+LOOP:
+	LF 	F1 (R2)
+	ADDF	F1 F1 F0
+	SF	F1 (R3)
+	ADDI 	R2 R2 #1
+	ADDI	R3 R3 #1
+	BNE	R2 R5 LOOP`;
+
+    context.superescalarCode.load(inputSuperescalar);
+    context.code.load(inputVLIW, context.superescalarCode);
+
+    expect(context.code.getLargeInstructionNumber()).toBe(15);
 });
 
 test('Loop.pla with extra \\n at the end does not throws error', t => {

--- a/src/test/unit/core/VLIW/VLIWParser.spec.ts
+++ b/src/test/unit/core/VLIW/VLIWParser.spec.ts
@@ -1,21 +1,21 @@
-import { expect, beforeEach, test } from 'vitest'
-import { VLIW } from '../../../../core/VLIW/VLIW';
-import { VLIWCode } from '../../../../core/VLIW/VLIWCode';
-import { Code } from '../../../../core/Common/Code';
-import { VLIWError } from '../../../../core/VLIW/VLIWError';
+import { beforeEach, expect, test } from "vitest";
+import { Code } from "../../../../core/Common/Code";
+import { VLIW } from "../../../../core/VLIW/VLIW";
+import { VLIWCode } from "../../../../core/VLIW/VLIWCode";
+import { VLIWError } from "../../../../core/VLIW/VLIWError";
 
-
-const context : { code: VLIWCode, superescalarCode: Code } = { code: null, superescalarCode: null };
+const context: { code: VLIWCode; superescalarCode: Code } = {
+  code: null,
+  superescalarCode: null,
+};
 
 beforeEach(() => {
-    context.code = new VLIWCode();
-    context.superescalarCode = new Code();
+  context.code = new VLIWCode();
+  context.superescalarCode = new Code();
 });
 
-test('Loop.pla is loaded properly', t => {
-
-    const inputVLIW =
-        `15
+test("Loop.pla is loaded properly", (t) => {
+  const inputVLIW = `15
     2	0 0 0 0	2 0 1 0
     3	1 0 0 0	4 0 1 0	3 4 0 0
     1	5 4 0 0
@@ -32,7 +32,7 @@ test('Loop.pla is loaded properly', t => {
     1	10 5 0 0 2 1 2
     1	9 0 1 0`;
 
-    const inputSuperescalar = `11
+  const inputSuperescalar = `11
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -46,18 +46,16 @@ LOOP:
 	ADDI	R3 R3 #1
 	BNE	R2 R5 LOOP`;
 
-    context.superescalarCode.load(inputSuperescalar);
-    context.code.load(inputVLIW, context.superescalarCode);
+  context.superescalarCode.load(inputSuperescalar);
+  context.code.load(inputVLIW, context.superescalarCode);
 
-    const error = `Bad instruction number parsed, expected 15, got ${context.code.getLargeInstructionNumber()}`;
+  const error = `Bad instruction number parsed, expected 15, got ${context.code.getLargeInstructionNumber()}`;
 
-    expect(context.code.getLargeInstructionNumber()).toBe(15);
+  expect(context.code.getLargeInstructionNumber()).toBe(15);
 });
 
-test('Loop.pla without lines number is loaded properly', t => {
-
-    const inputVLIW =
-        `    2	0 0 0 0	2 0 1 0
+test("Loop.pla without lines number is loaded properly", (t) => {
+  const inputVLIW = `    2	0 0 0 0	2 0 1 0
     3	1 0 0 0	4 0 1 0	3 4 0 0
     1	5 4 0 0
     0
@@ -73,7 +71,7 @@ test('Loop.pla without lines number is loaded properly', t => {
     1	10 5 0 0 2 1 2
     1	9 0 1 0`;
 
-    const inputSuperescalar = `ADDI	R2 R0 #50
+  const inputSuperescalar = `ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
 	LF	F0 (R4)
@@ -86,16 +84,14 @@ LOOP:
 	ADDI	R3 R3 #1
 	BNE	R2 R5 LOOP`;
 
-    context.superescalarCode.load(inputSuperescalar);
-    context.code.load(inputVLIW, context.superescalarCode);
+  context.superescalarCode.load(inputSuperescalar);
+  context.code.load(inputVLIW, context.superescalarCode);
 
-    expect(context.code.getLargeInstructionNumber()).toBe(15);
+  expect(context.code.getLargeInstructionNumber()).toBe(15);
 });
 
-test('Loop.pla with extra \\n at the end does not throws error', t => {
-
-    const inputVLIW =
-        `15
+test("Loop.pla with extra \\n at the end does not throws error", (t) => {
+  const inputVLIW = `15
     2	0 0 0 0	2 0 1 0
     3	1 0 0 0	4 0 1 0	3 4 0 0
     1	5 4 0 0
@@ -113,7 +109,7 @@ test('Loop.pla with extra \\n at the end does not throws error', t => {
     1	9 0 1 0
     `;
 
-    const inputSuperescalar = `11
+  const inputSuperescalar = `11
 	ADDI	R2 R0 #50
 	ADDI	R3 R0 #70
 	ADDI	R4 R0 #40
@@ -127,9 +123,9 @@ LOOP:
 	ADDI	R3 R3 #1
 	BNE	R2 R5 LOOP`;
 
-    context.superescalarCode.load(inputSuperescalar);
+  context.superescalarCode.load(inputSuperescalar);
 
-
-
-    expect(() => context.code.load(inputVLIW, context.superescalarCode)).not.toThrowError();
+  expect(() =>
+    context.code.load(inputVLIW, context.superescalarCode),
+  ).not.toThrowError();
 });


### PR DESCRIPTION
For backward compatibility reasons, the code parser support an initial line indicating the number of lines of the code that was ignored **but required**. As @icasrod pointed, this line shouldn't be required at all. This PR fixes this and also updates the examples shown in the load code modals.